### PR TITLE
Define abstract ancestor base class Agent

### DIFF
--- a/supply-demand-signals-2/header/Agent.h
+++ b/supply-demand-signals-2/header/Agent.h
@@ -1,0 +1,5 @@
+#pragma once
+
+class Agent {
+    virtual void on_time_step() = 0;
+};

--- a/supply-demand-signals-2/header/Distributor.h
+++ b/supply-demand-signals-2/header/Distributor.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -36,6 +37,7 @@ class Distributor : public Firm {
     void initialize_inventory(std::unordered_map<Product&, int> & inventory_items);
     int get_inventory(Product * product);
     bool is_overproduced(Product * product);
+    void on_time_step() override;
 
   private:
     std::vector<Producer *> suppliers;

--- a/supply-demand-signals-2/header/Distributor.h
+++ b/supply-demand-signals-2/header/Distributor.h
@@ -34,7 +34,7 @@ class Distributor : public Firm {
     void check_and_reorder();
     Producer * find_producer_for_product(Product * product);
     void receive_shipment(Product * product, int quantity);
-    void initialize_inventory(std::unordered_map<Product&, int> & inventory_items);
+    void initialize_inventory(std::unordered_map<Product *, int>& inventory_items);
     int get_inventory(Product * product);
     bool is_overproduced(Product * product);
     void on_time_step() override;

--- a/supply-demand-signals-2/header/Firm.h
+++ b/supply-demand-signals-2/header/Firm.h
@@ -5,7 +5,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "Firm.h"
+#include "Agent.h"
 #include "Machine.h"
 #include "Person.h"
 #include "Product.h"
@@ -27,7 +27,7 @@ struct Plan {
     int total_hours_remaining;
 };
 
-class Firm {
+class Firm : public Agent {
   public:
     std::vector<Machine*> machines;
     std::vector<Person*> workers;

--- a/supply-demand-signals-2/header/Person.h
+++ b/supply-demand-signals-2/header/Person.h
@@ -32,6 +32,7 @@ class Person : public Agent {
 	void shop();
     bool will_retire();
 	void retire();
+    void set_firm(Firm *);
   
   private:
     std::unordered_map<Ability, double> abilities;

--- a/supply-demand-signals-2/header/Person.h
+++ b/supply-demand-signals-2/header/Person.h
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "Agent.h"
 #include "Constants.h"
 #include "Product.h"
 
@@ -13,12 +14,12 @@ class Firm;
 class Society;
 
 
-class Person {
+class Person : public Agent {
   public:
     enum HealthStatus { HEALTHY, UNHEALTHY, RECOVERING };
 	
     Person();
-	void on_time_step();
+	void on_time_step() override;
   
     std::unordered_map<Product*, double>& get_purchase_frequencies();
     HealthStatus get_health_status();

--- a/supply-demand-signals-2/header/PriceController.h
+++ b/supply-demand-signals-2/header/PriceController.h
@@ -2,6 +2,7 @@
 #ifndef PRICE_CONTROLLER_H
 #define PRICE_CONTROLLER_H
 
+#include "Agent.h"
 #include "Constants.h"
 #include "Firm.h"
 #include "Product.h"
@@ -12,8 +13,9 @@
 
 struct Plan;
 
-class PriceController {
+class PriceController : public Agent {
     public:
+        void on_time_step() override;
         static void update_prices();
         static void get_price(Product * product);
         static void set_price(Product * product, double price);

--- a/supply-demand-signals-2/header/Producer.h
+++ b/supply-demand-signals-2/header/Producer.h
@@ -18,6 +18,7 @@ class Producer : public Firm {
     Producer();
     Producer(std::vector<Machine *> machines, std::vector<Person *> workforce);
     Producer(std::vector<Machine *> machines, std::vector<Person *> workforce, std::vector<Plan *> plans);
+    void on_time_step() override;
     
     void add_product_to_catalog(Product * product);
     bool can_produce(Product * product);

--- a/supply-demand-signals-2/header/Product.h
+++ b/supply-demand-signals-2/header/Product.h
@@ -7,13 +7,14 @@
 #include "Constants.h"
 
 struct Product {
+    Product(const std::string name, double price, int order);
+    int get_required_labor();
+    void add_input(Product * input, int quantity);
     std::string product_name;
     double price_per_unit;
     int order_size;
 	double base_frequency;
+    std::unordered_map<Product *, int> inputs;
 	std::vector<Ability> required_abilities;
   
-    Product(const std::string name, double price, int order);
-    int get_required_labor();
-    void add_input(Product & input, int quantity);
 };

--- a/supply-demand-signals-2/makefile
+++ b/supply-demand-signals-2/makefile
@@ -1,7 +1,49 @@
-APP = persontest
+APP = sim
+FLAGS = -Wall -Iheader -std=c++17
+HDR_DIR = header
+SRC_DIR = src
+BUILD_DIR = build
 
-${APP}: header/*.h src/*.cpp
-	g++ -Iheader -std=c++17  src/Person.cpp  src/Firm.cpp src/Society.cpp src/Machine.cpp src/Sim.cpp src/Product.cpp src/Distributor.cpp src/Producer.cpp -o $@
+${APP} : ${BUILD_DIR}/Product.o \
+	${BUILD_DIR}/Machine.o \
+	${BUILD_DIR}/Person.o \
+	${BUILD_DIR}/Firm.o \
+	${BUILD_DIR}/Producer.o \
+	${BUILD_DIR}/Distributor.o \
+	${BUILD_DIR}/PriceController.o \
+	${BUILD_DIR}/Society.o \
+	${BUILD_DIR}/Sim.o \
+	${SRC_DIR}/main.cpp
+	g++ ${FLAGS} $^ -o $@
 
-clean: 
-	rm -f ${APP}
+${BUILD_DIR}/Product.o : ${SRC_DIR}/Product.cpp
+	g++ ${FLAGS} -c $< -o $@
+
+${BUILD_DIR}/Machine.o : ${SRC_DIR}/Machine.cpp
+	g++ ${FLAGS} -c $< -o $@
+
+${BUILD_DIR}/Person.o : ${SRC_DIR}/Person.cpp
+	g++ ${FLAGS} -c $< -o $@
+
+${BUILD_DIR}/Firm.o : ${SRC_DIR}/Firm.cpp
+	g++ ${FLAGS} -c $< -o $@
+
+${BUILD_DIR}/Producer.o : ${SRC_DIR}/Producer.cpp
+	g++ ${FLAGS} -c $< -o $@
+
+${BUILD_DIR}/Distributor.o : ${SRC_DIR}/Distributor.cpp
+	g++ ${FLAGS} -c $< -o $@
+
+${BUILD_DIR}/PriceController.o : ${SRC_DIR}/PriceController.cpp
+	g++ ${FLAGS} -c $< -o $@
+
+${BUILD_DIR}/Society.o : ${SRC_DIR}/Society.cpp
+	g++ ${FLAGS} -c $< -o $@
+
+${BUILD_DIR}/Sim.o : ${SRC_DIR}/Sim.cpp
+	g++ ${FLAGS} -c $< -o $@
+
+clean:
+	rm -f ${BUILD_DIR}/*
+
+

--- a/supply-demand-signals-2/src/Distributor.cpp
+++ b/supply-demand-signals-2/src/Distributor.cpp
@@ -106,9 +106,9 @@ bool Distributor::is_overproduced(Product* product) {
     return false;
 }
 
-void Distributor::initialize_inventory(std::unordered_map<Product&, int> & inventory_items) {
+void Distributor::initialize_inventory(std::unordered_map<Product *, int>& inventory_items) {
     for(auto& items : inventory_items) {
-        inventory[&items.first] = items.second;
+        inventory[items.first] = items.second;
     }
 }
 

--- a/supply-demand-signals-2/src/Distributor.cpp
+++ b/supply-demand-signals-2/src/Distributor.cpp
@@ -106,9 +106,11 @@ bool Distributor::is_overproduced(Product* product) {
     return false;
 }
 
-
 void Distributor::initialize_inventory(std::unordered_map<Product&, int> & inventory_items) {
     for(auto& items : inventory_items) {
         inventory[&items.first] = items.second;
     }
+}
+
+void Distributor::on_time_step() {
 }

--- a/supply-demand-signals-2/src/Person.cpp
+++ b/supply-demand-signals-2/src/Person.cpp
@@ -107,4 +107,7 @@ void Person::on_time_step() {
 	if (will_shop()) { shop(); }
 	if (will_retire()) { retire(); }
 }
-		
+
+void Person::set_firm(Firm * workplace) {
+    firm = workplace;
+}

--- a/supply-demand-signals-2/src/PriceController.cpp
+++ b/supply-demand-signals-2/src/PriceController.cpp
@@ -3,6 +3,9 @@
 #include "Product.h"
 #include <iostream>
 
+void PriceController::on_time_step() {
+}
+
 void PriceController::update_prices() {
 
 }

--- a/supply-demand-signals-2/src/Producer.cpp
+++ b/supply-demand-signals-2/src/Producer.cpp
@@ -9,6 +9,9 @@ Producer::Producer(std::vector<Machine *> machines, std::vector<Person *> workfo
 Producer::Producer(std::vector<Machine *> machines, std::vector<Person *> workforce, std::vector<Plan *> plans) 
     : Firm(machines, workforce, plans) {}
 
+void Producer::on_time_step() {
+}
+
 void Producer::add_product_to_catalog(Product * product) {
     products.insert(product);
 }

--- a/supply-demand-signals-2/src/Product.cpp
+++ b/supply-demand-signals-2/src/Product.cpp
@@ -20,6 +20,6 @@ int Product::get_required_labor() {
     return 1;
 }
 
-void Product::add_input(Product & input, int quantity) {
-    inputs.push_back(std::unordered_map<Product&, int>({{input, quantity}}));
+void Product::add_input(Product * input, int quantity) {
+    inputs[input] = quantity;
 }

--- a/supply-demand-signals-2/src/Sim.cpp
+++ b/supply-demand-signals-2/src/Sim.cpp
@@ -1,30 +1,17 @@
 #include "Constants.h"
 #include "Sim.h"
 
+Sim::Sim() {
+	society = new Society();
+}
+
+int Sim::get_current_time_step() {
+	return current_time_step;
+}
+
+int Sim::current_time_step = 0;
+
 std::random_device Sim::rd;
 
 std::mt19937 Sim::gen(Sim::rd());
 
-Sim::Sim() {
-	society = new Society();
-}
-<<<<<<< HEAD
-=======
-
-int Sim::get_current_time_step() {
-	return current_time_step;
-}
-
-int Sim::current_time_step = 0;
-
-int Sim::get_current_time_step() {
-	return current_time_step;
-}
-
-int Sim::current_time_step = 0;
-
-int main() {
-	Sim simulation;
-	return EXIT_SUCCESS;
-}
->>>>>>> 1216f2094b18f1f7c0ad89c94cbb1d9b5b03f344

--- a/supply-demand-signals-2/src/main.cpp
+++ b/supply-demand-signals-2/src/main.cpp
@@ -1,17 +1,6 @@
-#include <iostream>
-#include <numeric>
-#include <string>
-#include <vector>
-
-#include "Firm.h"
-#include "Person.h"
-#include "Product.h"
-#include "Machine.h"
-#include "Producer.h"
-#include "Distributor.h"
-
+#include "Sim.h"
 
 int main() {
-    
-
+	Sim simulation;
+	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
- Defined an abstract `Agent` class with the one pure virtual function `on_time_step`.
- Had all agent classes that would need to be updated (agents proper) inherit from `Agent` and override `on_time_step`.
- Created a new top-level makefile that allows building of one module at a time.
- Fixed a number of build issues and warnings, as well as a few style issues.
- Removed the temporary `main` function from `Sim` and moved the logic to `main.cpp`.

Resolves #35 
