### PR TITLE
Refactor `Firm::check_and_reorder`, rename `recieve_order`, fix Ability placement

### DIFF
--- a/Agent-Based Simulation/header/Constants.h
+++ b/Agent-Based Simulation/header/Constants.h
@@ -2,8 +2,6 @@
 
 #include <cmath>
 
-enum Ability { ABILITY_1, ABILITY_2, ABILITY_3, NUM_ABILITIES }; 
-
 const int DAY = 24;
 const int WEEK = DAY * 7;
 const int MONTH = DAY * 30;

--- a/Agent-Based Simulation/header/Firm.h
+++ b/Agent-Based Simulation/header/Firm.h
@@ -78,8 +78,12 @@ class Firm : public Agent {
     std::unordered_map<Product*, std::vector<Plan*>> plan_history; // unused and prob need to change later
     std::vector<Plan*> plans_in_progress;
 
-    Producer * find_producer_for_product(Product * product);
     Producer * send_order(Order * order);
+    double get_reorder_threshold(Product * product);
+    int get_pending_inventory(Product * product);
+    void reorder_product_to_threshold(Product * product, 
+                                      double threshold,
+                                      int pending_inventory);
     void check_and_reorder();
 
 	double suitability(Person * person, std::vector<Ability>& required_abilities);

--- a/Agent-Based Simulation/header/Firm.h
+++ b/Agent-Based Simulation/header/Firm.h
@@ -8,7 +8,6 @@
 #include <queue>
 
 #include "Agent.h"
-#include "Constants.h"
 #include "Person.h"
 
 class Firm;
@@ -84,22 +83,24 @@ class Firm : public Agent {
     Producer * send_order(Order * order);
     double get_reorder_threshold(Product * product);
     int get_pending_inventory(Product * product);
-    void reorder_product_to_threshold(Product * product, 
-                                      double threshold,
-                                      int pending_inventory);
+    void reorder_product_to_threshold(
+        Product * product, 
+        double threshold,
+        int pending_inventory
+    );
     void check_and_reorder();
 
-	double suitability(Person * person, std::vector<Ability>& required_abilities);
-	double suitability(std::unordered_map<Ability, double>& abilities, 
-			           std::vector<Ability>& required_abilities,
+	double suitability(Person * person, std::vector<Person::Ability>& required_abilities);
+	double suitability(std::unordered_map<Person::Ability, double>& abilities, 
+			           std::vector<Person::Ability>& required_abilities,
 					   float productivity);
 	int predict_workers_needed(Order * order);
-	void assign_workers_by_suitability_threshold(Plan * draft_plan, std::vector<Ability>& required_abilities, double suitability_threshold);
+	void assign_workers_by_suitability_threshold(Plan * draft_plan, std::vector<Person::Ability>& required_abilities, double suitability_threshold);
 	int predict_turnaround_time(Order * order, double total_suitability); 
 	int predict_labor_hours(Order * order, double total_suitability);
-	void assign_plan_dependent_fields(Plan * draft_plan, std::vector<Ability>& required_abilities);
-	void draft_optimal_plan(Plan * draft_plan, std::vector<Ability>& required_abilities);
-	void train_workers(std::vector<Person *>& workers, std::vector<Ability>& required_abilities);
+	void assign_plan_dependent_fields(Plan * draft_plan, std::vector<Person::Ability>& required_abilities);
+	void draft_optimal_plan(Plan * draft_plan, std::vector<Person::Ability>& required_abilities);
+	void train_workers(std::vector<Person *>& workers, std::vector<Person::Ability>& required_abilities);
     void add_demand_signal(Product * product, int quantity);
     void apply_demand_window();
     virtual std::unordered_set<Product *> get_products_to_reorder() = 0;

--- a/Agent-Based Simulation/header/Firm.h
+++ b/Agent-Based Simulation/header/Firm.h
@@ -38,10 +38,13 @@ struct Plan {
 };
 
 struct Order {
+    enum OrderStatus { ORDER_REQUESTED, ORDER_FINISHED };
+
     Product * product;
     int quantity;
     Firm * customer;
     int requested_turnaround_time;
+    OrderStatus status;
 };
 
 struct DemandSignal {
@@ -65,7 +68,7 @@ class Firm : public Agent {
 	bool has_product(Product * product);
     int get_inventory(Product * product);
     void add_supplier(Producer * producer);
-    void receive_order(Order * order);
+    void receive_shipment(Order * order);
 
   protected:
     std::vector<Producer *> suppliers;

--- a/Agent-Based Simulation/header/Person.h
+++ b/Agent-Based Simulation/header/Person.h
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include "Agent.h"
-#include "Constants.h"
 
 struct Product;
 class Distributor;
@@ -13,6 +12,7 @@ class Firm;
 class Person : public Agent {
   public:
     enum HealthStatus { HEALTHY, UNHEALTHY };
+    enum Ability { ABILITY_1, ABILITY_2, ABILITY_3, NUM_ABILITIES }; 
 	
     Person();
 	void on_time_step() override;

--- a/Agent-Based Simulation/header/Product.h
+++ b/Agent-Based Simulation/header/Product.h
@@ -4,7 +4,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "Constants.h"
+#include "Person.h"
 
 struct Machine;
 
@@ -17,6 +17,6 @@ struct Product {
     std::vector<Machine *> machines_needed;
     std::unordered_map<Product *, double> inputs_per_unit;
  	double living_labor_per_unit; 
-	std::vector<Ability> required_abilities;
+	std::vector<Person::Ability> required_abilities;
 	double mean_consumption_frequency;
 };

--- a/Agent-Based Simulation/src/Firm.cpp
+++ b/Agent-Based Simulation/src/Firm.cpp
@@ -40,11 +40,15 @@ void Firm::add_supplier(Producer * producer) {
     suppliers.push_back(producer);
 }
 
-void Firm::receive_order(Order * order) {
+void Firm::receive_shipment(Order * order) {
+    if (order->status != Order::ORDER_FINISHED) {
+        std::cerr << "Attempted to recieve a shipment for an incomplete order." << std::endl;
+        return;
+    }
     inventory[order->product] += order->quantity;
     product_to_outbound_orders[order->product].erase(order);
     std::cout << "Received " << order->quantity << " units of " 
-              << order->product->product_name << ". New inventory: " 
+              << order->product->product_name << ". New inventory level: " 
               << inventory[order->product] << std::endl;
 }
 
@@ -101,7 +105,8 @@ void Firm::reorder_product_to_threshold(
             product,
             discrepancy,
             this,
-            (int) (pending_inventory / threshold * FIRM_STOCKPILE_DURATION)
+            (int) (pending_inventory / threshold * FIRM_STOCKPILE_DURATION),
+            Order::ORDER_REQUESTED
         };
 
         Producer * chosen_producer = send_order(order);

--- a/Agent-Based Simulation/src/Firm.cpp
+++ b/Agent-Based Simulation/src/Firm.cpp
@@ -48,15 +48,6 @@ void Firm::receive_order(Order * order) {
               << inventory[order->product] << std::endl;
 }
 
-Producer * Firm::find_producer_for_product(Product * product) {
-    for (Producer * producer : suppliers) {
-        if (producer->can_produce(product)) {
-            return producer;
-        }
-    }
-    return nullptr;
-}
-
 Producer * Firm::send_order(Order * order) {
     int order_time = INT_MAX;
     Producer * chosen_producer = nullptr;
@@ -73,8 +64,8 @@ Producer * Firm::send_order(Order * order) {
         chosen_producer->pursue_order(order);
         product_to_outbound_orders[order->product].insert(order);
     }
-    for(auto * producer : suppliers) {
-        if(producer != chosen_producer) {
+    for (auto * producer : suppliers) {
+        if (producer != chosen_producer) {
             producer->drop_order(order);
         }
     }
@@ -82,43 +73,55 @@ Producer * Firm::send_order(Order * order) {
     return chosen_producer;
 }
 
+double Firm::get_reorder_threshold(Product * product) {
+    return std::max((double) product->order_size, 
+        inventory_demands[product] * FIRM_STOCKPILE_DURATION);
+}
+
+int Firm::get_pending_inventory(Product * product) {
+    int pending_inventory = inventory[product];
+    for (auto * order : product_to_outbound_orders[product]) {
+        pending_inventory += order->quantity;
+    }
+    return pending_inventory;
+}
+
+void Firm::reorder_product_to_threshold(
+        Product * product,
+        double threshold,
+        int pending_inventory
+        ) {
+    if (pending_inventory < threshold) {
+        int discrepancy = product->order_size * 
+            ((int) std::ceil(threshold - pending_inventory) / product->order_size);
+        std::cout << "Reordering " << discrepancy << " units of " 
+                  << product->product_name << std::endl;
+
+        Order * order = new Order{
+            product,
+            discrepancy,
+            this,
+            (int) (pending_inventory / threshold * FIRM_STOCKPILE_DURATION)
+        };
+
+        Producer * chosen_producer = send_order(order);
+        if (chosen_producer) {
+            std::cout << "Order accepted. Turnaround time: " 
+                      << order->requested_turnaround_time << " days" << std::endl;
+        } else {
+            std::cerr << "No producer found for product: " 
+                      << product->product_name << std::endl;
+        }
+    }
+}
+
 void Firm::check_and_reorder() {
     std::unordered_set<Product *> products_to_reorder = get_products_to_reorder();
     for (Product * product : products_to_reorder) {
-        int current_inventory = inventory[product];
-       
-        double threshold = std::max((double) product->order_size, 
-            inventory_demands[product] * FIRM_STOCKPILE_DURATION);
-
-        int pending_inventory = current_inventory;
-        for (auto * order : product_to_outbound_orders[product]) {
-            pending_inventory += order->quantity;
-        }
-        
+        double threshold = get_reorder_threshold(product);
+        int pending_inventory = get_pending_inventory(product);
         if (pending_inventory < threshold) {
-            Producer * producer = find_producer_for_product(product);
-            if (producer) {
-                int discrepancy = product->order_size * 
-                    ((int) std::ceil(threshold - pending_inventory) / product->order_size);
-                std::cout << "Reordering " << discrepancy << " units of " 
-                          << product->product_name << std::endl;
-
-                Order * order = new Order{
-                    product,
-                    discrepancy,
-                    this,
-                    (int) (pending_inventory / threshold * FIRM_STOCKPILE_DURATION)
-                };
-
-				send_order(order);
-                if (order) {
-                    std::cout << "Order accepted. Turnaround time: " 
-                              << order->requested_turnaround_time << " days" << std::endl;
-                }
-            } else {
-                std::cerr << "No producer found for product: " 
-                          << product->product_name << std::endl;
-            }
+            reorder_product_to_threshold(product, threshold, pending_inventory);
         }
     }
 }

--- a/Agent-Based Simulation/src/Firm.cpp
+++ b/Agent-Based Simulation/src/Firm.cpp
@@ -1,5 +1,6 @@
 #include <numeric>
 
+#include "Constants.h"
 #include "Distributor.h"
 #include "Firm.h"
 #include "Person.h"
@@ -133,7 +134,7 @@ void Firm::check_and_reorder() {
 
 double Firm::suitability(
     Person * person,
-    std::vector<Ability>& required_abilities
+    std::vector<Person::Ability>& required_abilities
     ) {
 	return suitability(person->get_abilities(),
 			           required_abilities,
@@ -141,12 +142,12 @@ double Firm::suitability(
 }
 
 double Firm::suitability(
-    std::unordered_map<Ability, double>& abilities,
-    std::vector<Ability>& required_abilities,
+    std::unordered_map<Person::Ability, double>& abilities,
+    std::vector<Person::Ability>& required_abilities,
     float productivity
     ) {
 	double suitability = 0.0;
-	for (Ability ability : required_abilities) {
+	for (Person::Ability ability : required_abilities) {
 		suitability += abilities[ability];
 	}
 	suitability /= required_abilities.size();
@@ -166,7 +167,7 @@ int Firm::predict_workers_needed(Order * order) {
 
 void Firm::assign_workers_by_suitability_threshold(
         Plan * draft_plan,
-        std::vector<Ability>& required_abilities,
+        std::vector<Person::Ability>& required_abilities,
         double suitability_threshold
         ) {
     std::unordered_map<Person *, double> worker_to_suitability;
@@ -221,13 +222,13 @@ int Firm::predict_labor_hours(Order * order, double total_suitability) {
 
 void Firm::assign_plan_dependent_fields(
         Plan * draft_plan,
-        std::vector<Ability>& required_abilities
+        std::vector<Person::Ability>& required_abilities
         ) {
 	double total_suitability = 0.0;
 	if (draft_plan->training_time) {
-		std::unordered_map<Ability, double> max_required_abilities;
+		std::unordered_map<Person::Ability, double> max_required_abilities;
 		for (Person * worker : draft_plan->workers) {
-			for (Ability ability : required_abilities) {
+			for (Person::Ability ability : required_abilities) {
 				max_required_abilities[ability] = std::max(max_required_abilities[ability],
 						 								   worker->get_abilities()[ability]);
 			}
@@ -268,7 +269,7 @@ void Firm::assign_plan_dependent_fields(
 
 void Firm::draft_optimal_plan(
         Plan * draft_plan,
-        std::vector<Ability>& required_abilities
+        std::vector<Person::Ability>& required_abilities
         ) {
     // try without training first
     Plan * draft_plan_without_training = new Plan(*draft_plan);
@@ -306,11 +307,11 @@ void Firm::draft_optimal_plan(
 
 void Firm::train_workers(
         std::vector<Person *>& workers,
-        std::vector<Ability>& required_abilities
+        std::vector<Person::Ability>& required_abilities
         ) {
-    std::unordered_map<Ability, double> max_required_abilities;
+    std::unordered_map<Person::Ability, double> max_required_abilities;
     for (Person * worker : workers) {
-        for (Ability ability : required_abilities) {
+        for (Person::Ability ability : required_abilities) {
             max_required_abilities[ability] =
                 std::max(
                         max_required_abilities[ability],

--- a/Agent-Based Simulation/src/Person.cpp
+++ b/Agent-Based Simulation/src/Person.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <random>
 
+#include "Constants.h"
 #include "Firm.h"
 #include "Distributor.h"
 #include "Person.h"
@@ -23,13 +24,13 @@ Person::Person():
 
         static std::normal_distribution<>
             ability_dist(1.0, PERSON_ABILITY_STDDEV);
-        std::vector<Ability> all_abilities;
-        for (int i = 0; i < NUM_ABILITIES; i++) {
-            all_abilities.push_back((Ability) i);
+        std::vector<Person::Ability> all_abilities;
+        for (int i = 0; i < Person::NUM_ABILITIES; i++) {
+            all_abilities.push_back((Person::Ability) i);
         }
         std::shuffle(all_abilities.begin(), all_abilities.end(), Sim::gen);
         all_abilities.resize(PERSON_ABILITY_COUNT_MAX);
-        for (Ability ability : all_abilities) {
+        for (Person::Ability ability : all_abilities) {
             abilities[ability] = std::max(0.0, ability_dist(Sim::gen));
         }
         ranked_distributors = Society::instance->get_distributors();
@@ -46,11 +47,11 @@ Person::Person():
         }
     }
 
-std::unordered_map<Ability, double>& Person::get_abilities() {
+std::unordered_map<Person::Ability, double>& Person::get_abilities() {
     return this->abilities;
 }
 
-void Person::train(std::unordered_map<Ability, double> target_abilities) {
+void Person::train(std::unordered_map<Person::Ability, double> target_abilities) {
     // can introduce < 100% effectiveness on training later
     for (auto &pair : target_abilities) {
         abilities[pair.first] = pair.second;

--- a/Agent-Based Simulation/src/Producer.cpp
+++ b/Agent-Based Simulation/src/Producer.cpp
@@ -123,12 +123,13 @@ void Producer::execute_plan(Plan * plan) {
 }
 
 void Producer::end_plan(Plan * plan) {
+    plan->order->status = Order::ORDER_FINISHED;
 	// simplification: whole product amount is added to inventory at the end of
     // a plan
 	inventory[plan->order->product] += plan->order->quantity;
 	// simplification: product shipped instantly
 	inventory[plan->order->product] -= plan->order->quantity;
-	plan->order->customer->receive_order(plan->order);
+	plan->order->customer->receive_shipment(plan->order);
     plan->prd += PriceController::get_price(plan->order->product) * plan->order->quantity;
 }
 

--- a/Agent-Based Simulation/src/Product.cpp
+++ b/Agent-Based Simulation/src/Product.cpp
@@ -15,8 +15,8 @@ Product::Product(const std::string name) : product_name{name} {
                 PRODUCT_LABOR_PER_UNIT_MAX
                 );
     living_labor_per_unit = (double)living_labor_dist(Sim::gen);
-    for (int i = 0; i < NUM_ABILITIES; i++) {
-        required_abilities.push_back((Ability) i);
+    for (int i = 0; i < Person::NUM_ABILITIES; i++) {
+        required_abilities.push_back((Person::Ability) i);
     }
     shuffle(required_abilities.begin(), required_abilities.end(), Sim::gen);
     static std::uniform_int_distribution<>


### PR DESCRIPTION
Resolves #70, #73 

I found that I was able to move Ability back to Person without any issues (probably because of the better header organization), so I did that, changing `Ability` into `Person::Ability`.