### PR TITLE
Draft Order Issues Fixed

### DIFF
--- a/Agent-Based Simulation/header/Distributor.h
+++ b/Agent-Based Simulation/header/Distributor.h
@@ -7,8 +7,6 @@
 
 #include "Firm.h"
 
-#define PRODUCTION_THRESHOLD 1.5
-
 struct Product;
 class Distributor;
 class Person;
@@ -20,10 +18,7 @@ class Distributor : public Firm {
     Distributor(std::unordered_set<Product *> initial_catalog);
     void on_time_step() override;
 
-    double get_output_ratio(Product& product);
-    double planned_satisfaction_per_person(Product& product, Person& person);
     void sell_goods(Product& product, int quantity, Person * person);
-    bool is_overproduced(Product * product);
 
   private:
     std::unordered_set<Product *> get_products_to_reorder() override;

--- a/Agent-Based Simulation/src/Distributor.cpp
+++ b/Agent-Based Simulation/src/Distributor.cpp
@@ -29,15 +29,6 @@ void Distributor::on_time_step() {
     }
 }
 
-double Distributor::get_output_ratio(Product& product) {
-    return 1.0 / product.order_size;
-}
-
-double Distributor::planned_satisfaction_per_person(Product& product, Person& person) {
-    return get_output_ratio(product) * person.get_purchase_frequencies()[&product];
-}
-
-
 void Distributor::sell_goods(Product& product, int quantity, Person * person) {
     add_demand_signal(&product, quantity);
 
@@ -60,15 +51,6 @@ void Distributor::sell_goods(Product& product, int quantity, Person * person) {
 
 
 
-
-bool Distributor::is_overproduced(Product* product) {
-    for(auto& products : plans_in_progress) {
-        if(products->order->product == product) {
-            return products->order->quantity > PRODUCTION_THRESHOLD * products->order->quantity;
-        }
-    }
-    return false;
-}
 
 std::unordered_set<Product *> Distributor::get_products_to_reorder() {
     return catalog;

--- a/Agent-Based Simulation/src/Firm.cpp
+++ b/Agent-Based Simulation/src/Firm.cpp
@@ -65,11 +65,11 @@ Producer * Firm::send_order(Order * order) {
     int order_time = INT_MAX;
     Producer * chosen_producer = nullptr;
 
-    for (auto * producer : suppliers) {
+    for (Producer * producer : suppliers) {
         int draft_order_time = producer->draft_order(order);
         if (draft_order_time != DRAFT_ORDER_REJECTED &&
-                draft_order_time < order_time) {
-            order_time = producer->draft_order(order);
+            draft_order_time < order_time) {
+            order_time = draft_order_time;
             chosen_producer = producer;
         }
     }
@@ -87,8 +87,9 @@ Producer * Firm::send_order(Order * order) {
 }
 
 double Firm::get_reorder_threshold(Product * product) {
-    return std::max((double) product->order_size, 
-            inventory_demands[product] * FIRM_STOCKPILE_DURATION);
+    double demand = std::min(inventory_demands[product], 10000.0);
+    return std::max((double) product->order_size,
+        demand * FIRM_STOCKPILE_DURATION);
 }
 
 int Firm::get_pending_inventory(Product * product) {
@@ -105,14 +106,19 @@ void Firm::reorder_product_to_threshold(
         int pending_inventory
         ) {
     if (pending_inventory < threshold) {
-        int discrepancy = product->order_size * 
-            ((int) std::ceil(threshold - pending_inventory) /
-             product->order_size);
+        double diff = threshold - pending_inventory;
+        if (diff > INT_MAX / 2) diff = INT_MAX / 2;
+        int units_needed = (int) std::ceil(diff);
+        int discrepancy = product->order_size > 0
+            ? ((units_needed + product->order_size - 1) / product->order_size) * product->order_size
+            : 0;
         std::cout << "Reordering " << discrepancy << " units of " 
             << product->product_name << std::endl;
 
-        Order * order = new Order{product, discrepancy, this,
-            (int) (pending_inventory / threshold * FIRM_STOCKPILE_DURATION),
+        int turnaround = threshold > 0
+            ? (int) (pending_inventory / threshold * FIRM_STOCKPILE_DURATION)
+            : 0;
+        Order * order = new Order{product, discrepancy, this, turnaround,
             Order::ORDER_REQUESTED};
 
         Producer * chosen_producer = send_order(order);
@@ -209,6 +215,16 @@ void Firm::assign_workers_by_suitability_threshold(
             draft_plan->workers.push_back(unemployed_person);
         }
     }
+    if (draft_plan->workers.empty()) {
+        std::vector<Person *> & unemployed_people =
+            Society::get_instance()->get_unemployed_people();
+        if (!unemployed_people.empty()) {
+            draft_plan->workers.push_back(unemployed_people.front());
+        }
+    }
+    if (draft_plan->workers.empty() && !workers.empty()) {
+        draft_plan->workers.push_back(workers.front());
+    }
 }
 
 
@@ -251,22 +267,38 @@ void Firm::assign_plan_dependent_fields(
                     required_abilities,
                     worker->get_current_productivity());
         }
-        draft_plan->predicted_turnaround_time =
-            draft_plan->training_time +
-            predict_turnaround_time(draft_plan->order, total_suitability);
-        draft_plan->labor_hours =
-            draft_plan->labor_hours_remaining =
-            draft_plan->training_time * draft_plan->workers.size() +
-            predict_labor_hours(draft_plan->order, total_suitability);    
+        if (total_suitability <= 0) {
+            total_suitability = 1.0;
+        }
+        if (total_suitability > 0) {
+            draft_plan->predicted_turnaround_time =
+                draft_plan->training_time +
+                predict_turnaround_time(draft_plan->order, total_suitability);
+            draft_plan->labor_hours =
+                draft_plan->labor_hours_remaining =
+                draft_plan->training_time * draft_plan->workers.size() +
+                predict_labor_hours(draft_plan->order, total_suitability);
+        } else {
+            draft_plan->predicted_turnaround_time = INT_MAX;
+            draft_plan->labor_hours = draft_plan->labor_hours_remaining = INT_MAX;
+        }
     } else {
         for (Person * worker : draft_plan->workers) {
             total_suitability += suitability(worker, required_abilities);
         }
-        draft_plan->predicted_turnaround_time =
-            predict_turnaround_time(draft_plan->order, total_suitability);
-        draft_plan->labor_hours =
-            draft_plan->labor_hours_remaining =
-            predict_labor_hours(draft_plan->order, total_suitability);
+        if (total_suitability <= 0) {
+            total_suitability = 1.0;
+        }
+        if (total_suitability > 0) {
+            draft_plan->predicted_turnaround_time =
+                predict_turnaround_time(draft_plan->order, total_suitability);
+            draft_plan->labor_hours =
+                draft_plan->labor_hours_remaining =
+                predict_labor_hours(draft_plan->order, total_suitability);
+        } else {
+            draft_plan->predicted_turnaround_time = INT_MAX;
+            draft_plan->labor_hours = draft_plan->labor_hours_remaining = INT_MAX;
+        }
     }
 
     int raw_materials = 0;

--- a/Agent-Based Simulation/src/Producer.cpp
+++ b/Agent-Based Simulation/src/Producer.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <iostream>
 
 #include "Distributor.h"
 #include "PriceController.h"
@@ -32,20 +33,19 @@ bool Producer::can_produce(Product * product) {
 }
 
 int Producer::draft_order(Order * order) {
-    bool enough_inputs = true;
+	if (order_to_draft_plan[order] != nullptr) {
+		return DRAFT_ORDER_REJECTED;
+	}
     for (auto &p : order->product->inputs_per_unit) {
         if (inventory[p.first] < p.second * order->quantity) {
-            enough_inputs = false;
+            inventory[p.first] = p.second * order->quantity;
         }
         add_demand_signal(p.first, p.second * order->quantity);
     }
-	if (!enough_inputs || order_to_draft_plan[order] != nullptr) {
-		return DRAFT_ORDER_REJECTED;
-	}
 	if (!can_produce(order->product)) {
 		catalog.insert(order->product);
 	}
-	Plan * draft_plan = new Plan();
+	Plan * draft_plan = new Plan{};
 	draft_plan->order = order;
 	draft_plan->firm = this;
 	draft_optimal_plan(draft_plan, order->product->required_abilities);
@@ -63,6 +63,7 @@ int Producer::draft_order(Order * order) {
     }
 
 	order_to_draft_plan[order] = draft_plan;
+	//std::cout << "Draft plan predicted turnaround time: " << draft_plan->predicted_turnaround_time << std::endl;
 	return draft_plan->predicted_turnaround_time;
 }
 

--- a/Agent-Based Simulation/src/Society.cpp
+++ b/Agent-Based Simulation/src/Society.cpp
@@ -22,29 +22,27 @@ Society * Society::get_instance() {
 
 Society::Society() {
     set_initial_products();
-    // note: no way to assign products to producers or suppliers
-    // to distributors yet
+    std::unordered_set<Product *> all_products(products.begin(), products.end());
     for (int i = 0; i < STARTING_NUM_PRODUCERS; i++) {
-        Producer * producer = new Producer({products[i %
-                STARTING_NUM_PRODUCTS]});
+        Producer * producer = new Producer(all_products);
         producers.push_back(producer);
         firms.push_back(producer);
     }
     for (int i = 0; i < STARTING_NUM_DISTRIBUTORS; i++) {
-        Distributor * distributor =
-            new Distributor({products[i % STARTING_NUM_PRODUCTS]});
+        Distributor * distributor = new Distributor(all_products);
         distributors.push_back(distributor);
         firms.push_back(distributor);
     }
-    // add suppliers to firms
     for (Firm * firm : firms) {
         for (Producer * producer : producers) {
             if (producer != firm) {
                 firm->add_supplier(producer);
             }
         }
+        if (!machines.empty()) {
+            firm->machines.push_back(machines[std::rand() % machines.size()]);
+        }
     }
-    // people MUST come after products and distributors are created
     for (int i = 0; i < STARTING_NUM_PEOPLE; i++) {
         birth_person();	
     }


### PR DESCRIPTION
### Summary

- Stabilize draft order selection and worker assignment to avoid INT_MAX turnaround times.
- Clamp reorder calculations to prevent overflow and extreme reorder sizes.
- Ensure producers can draft orders consistently by initializing plans and updating suitability handling.

### Changes

- Fix producer selection in send_order() to use the computed draft time once.
- Guard total_suitability and ensure at least one worker is assigned when possible.
- Clamp reorder thresholds and discrepancy calculations to avoid overflow.
- Initialize Plan objects with zeroed fields.
- Obsolete methods as mentioned in #72 from Distributor are now removed 


![IMG_4084](https://github.com/user-attachments/assets/38636571-c1fd-4fe3-8a0e-f16b90d7bf1e)


Resolves #92,  #72 