### PR TITLE
Distinguish machines from other inputs; provide producers with necessary machines for initial products

### DIFF
--- a/Agent-Based Simulation/header/Firm.h
+++ b/Agent-Based Simulation/header/Firm.h
@@ -55,9 +55,6 @@ struct DemandSignal {
 
 class Firm : public Agent {
   public:
-    std::vector<Machine*> machines;
-    std::vector<Person*> workers;
-	
 	Firm();
     Firm(std::unordered_set<Product *> initial_catalog);
     void on_time_step() override;
@@ -71,6 +68,9 @@ class Firm : public Agent {
     void receive_shipment(Order * order);
 
   protected:
+    std::vector<Machine*> machines;
+    std::vector<Person*> workers;
+	
     std::vector<Producer *> suppliers;
     std::unordered_map<Product *, int> inventory;
     std::unordered_set<Product *> catalog;
@@ -96,7 +96,11 @@ class Firm : public Agent {
 			           std::vector<Person::Ability>& required_abilities,
 					   float productivity);
 	int predict_workers_needed(Order * order);
-	void assign_workers_by_suitability_threshold(Plan * draft_plan, std::vector<Person::Ability>& required_abilities, double suitability_threshold);
+    void assign_workers_by_suitability_threshold(
+            Plan * draft_plan,
+            std::vector<Person::Ability>& required_abilities,
+            double suitability_threshold
+            );
 	int predict_turnaround_time(Order * order, double total_suitability); 
 	int predict_labor_hours(Order * order, double total_suitability);
 	void assign_plan_dependent_fields(Plan * draft_plan, std::vector<Person::Ability>& required_abilities);

--- a/Agent-Based Simulation/header/Producer.h
+++ b/Agent-Based Simulation/header/Producer.h
@@ -27,11 +27,9 @@ class Producer : public Firm {
 
   private:
 	std::unordered_map<Order *, Plan *> order_to_draft_plan;
-
 	void start_plan(Plan * plan);
 	void execute_plan(Plan * plan);
 	void end_plan(Plan * plan);
-
 	void execute_plans();
     std::unordered_set<Product *> get_products_to_reorder() override;
 };

--- a/Agent-Based Simulation/header/Society.h
+++ b/Agent-Based Simulation/header/Society.h
@@ -16,6 +16,7 @@ class Producer;
 class Society : public Agent {
     public:
         static Society * get_instance();
+        std::vector<Product *>& get_goods();
         std::vector<Product *>& get_products();
         std::vector<Distributor *>& get_distributors();
         std::vector<Person *>& get_unemployed_people();
@@ -40,9 +41,10 @@ class Society : public Agent {
         std::vector<Producer *> producers;
         std::unordered_map<Product *, std::vector<Distributor *>>
             product_to_distributors;
-        std::vector<Product *> products;
+        std::vector<Product *> goods;
         std::unordered_map<Product *, std::size_t> product_to_index;
         std::vector<Machine *> machines;
+        std::vector<Product *> products;
         std::vector<Distributor *> distributors;
         int current_work_hours_daily = INITIAL_WORK_HOURS_DAILY;
 		int current_work_days_weekly = INITIAL_WORK_DAYS_WEEKLY;

--- a/Agent-Based Simulation/src/Distributor.cpp
+++ b/Agent-Based Simulation/src/Distributor.cpp
@@ -62,9 +62,9 @@ void Distributor::sell_goods(Product& product, int quantity, Person * person) {
 }
 
 bool Distributor::is_overproduced(Product* product) {
-    for(auto& products : plans_in_progress) {
-        if(products->order->product == product) {
-            return products->order->quantity > PRODUCTION_THRESHOLD * products->order->quantity;
+    for(auto& goods : plans_in_progress) {
+        if(goods->order->product == product) {
+            return goods->order->quantity > PRODUCTION_THRESHOLD * goods->order->quantity;
         }
     }
     return false;

--- a/Agent-Based Simulation/src/Person.cpp
+++ b/Agent-Based Simulation/src/Person.cpp
@@ -43,7 +43,7 @@ Person::Person(Society * society):
                 );
         static std::normal_distribution<>
             dist(1, PERSON_FREQUENCY_MULTIPLIER_STDDEV);
-        for (Product * p : society->get_products()) {
+        for (Product * p : society->get_goods()) {
             purchase_frequencies[p] =
                 p->mean_consumption_frequency * std::abs(dist(Sim::gen));
         }

--- a/Agent-Based Simulation/src/Producer.cpp
+++ b/Agent-Based Simulation/src/Producer.cpp
@@ -13,9 +13,20 @@
 Producer::Producer() : Firm() {}
 
 Producer::Producer(std::unordered_set<Product *> initial_catalog) :
-    Firm(initial_catalog) {
-    for (Product * p : get_products_to_reorder()) {
-        inventory[p] = get_reorder_threshold(p) * FIRM_INITIAL_INVENTORY_MULTIPLIER;
+    Firm(initial_catalog)
+{
+    std::unordered_set<Machine *> initial_machines;
+    for (Product * product : initial_catalog) {
+        for (Machine * machine : product->machines_needed) {
+            initial_machines.insert(machine);
+        }
+    }
+    for (Machine * machine : initial_machines) {
+        machines.push_back(machine);
+    }
+    for (Product * product : get_products_to_reorder()) {
+        inventory[product] =
+            get_reorder_threshold(product) * FIRM_INITIAL_INVENTORY_MULTIPLIER;
     }
 }
 

--- a/Agent-Based Simulation/src/Product.cpp
+++ b/Agent-Based Simulation/src/Product.cpp
@@ -35,12 +35,12 @@ Product::Product(const std::string name) : product_name{name} {
     mean_consumption_frequency = frequency_dist(Sim::gen);
 }
 
-void Product::set_inputs(std::vector<Product *>& products) {
+void Product::set_inputs(std::vector<Product *>& goods) {
     static std::uniform_int_distribution<>
         num_inputs_dist(PRODUCT_NUM_INPUTS_MIN, PRODUCT_NUM_INPUTS_MAX);
     const std::size_t num_inputs = num_inputs_dist(Sim::gen);
     std::uniform_int_distribution<>
-        product_input_index_dist(0, products.size() - 1);
+        product_input_index_dist(0, goods.size() - 1);
     std::set<int> indices;
     while (indices.size() < num_inputs) {
         indices.insert(product_input_index_dist(Sim::gen));
@@ -51,7 +51,7 @@ void Product::set_inputs(std::vector<Product *>& products) {
                 PRODUCT_INPUT_PER_UNIT_MAX
                 );
     for (int index : indices) {
-        inputs_per_unit[products[index]] = input_per_unit_dist(Sim::gen);
+        inputs_per_unit[goods[index]] = input_per_unit_dist(Sim::gen);
     }
 }
 

--- a/Agent-Based Simulation/src/Society.cpp
+++ b/Agent-Based Simulation/src/Society.cpp
@@ -3,6 +3,7 @@
 #include <Eigen/Eigenvalues>
 #include <iostream>
 #include <numeric>
+#include <sstream>
 #include <stdexcept>
 #include <unordered_map>
 
@@ -22,17 +23,17 @@ Society * Society::get_instance() {
 
 Society::Society() {
     set_initial_products();
-    // note: no way to assign products to producers or suppliers
+    // note: no way to assign goods to producers or suppliers
     // to distributors yet
     for (int i = 0; i < STARTING_NUM_PRODUCERS; i++) {
-        Producer * producer = new Producer({products[i %
+        Producer * producer = new Producer({goods[i %
                 STARTING_NUM_PRODUCTS]});
         producers.push_back(producer);
         firms.push_back(producer);
     }
     for (int i = 0; i < STARTING_NUM_DISTRIBUTORS; i++) {
         Distributor * distributor =
-            new Distributor({products[i % STARTING_NUM_PRODUCTS]});
+            new Distributor({goods[i % STARTING_NUM_PRODUCTS]});
         distributors.push_back(distributor);
         firms.push_back(distributor);
     }
@@ -44,7 +45,7 @@ Society::Society() {
             }
         }
     }
-    // people MUST come after products and distributors are created
+    // people MUST come after goods and distributors are created
     for (int i = 0; i < STARTING_NUM_PEOPLE; i++) {
         birth_person();	
     }
@@ -54,6 +55,7 @@ void Society::set_initial_products() {
     std::size_t i = 0;
     for (; i < STARTING_NUM_PRODUCTS; ++i) {
         Product * new_product = new Product("Product " + std::to_string(i));
+        goods.push_back(new_product);
         products.push_back(new_product);
         product_to_index[new_product] = i;
     }
@@ -68,9 +70,9 @@ void Society::set_initial_products() {
         products.push_back(new_machine);
         product_to_index[new_machine] = i;
     }
-    for (Product * product: products) {
-        product->set_inputs(products);
-        product->set_machines(machines);
+    for (Product * good: goods) {
+        good->set_inputs(goods);
+        good->set_machines(machines);
     }
     set_product_prices();
 }
@@ -156,8 +158,10 @@ void Society::set_product_prices() {
     }
     Eigen::VectorXd values = get_leontief_function(A, l);
     for (std::size_t i = 0; i < dim; ++i) {
-        if (values(i) < 0.0) {
-            throw std::domain_error("Value < 0.");
+        if (values(i) <= 0.0) {
+            std::stringstream message;
+            message << "Value of item " << i << " <= 0.";
+            throw std::domain_error(message.str());
         }
         products[i]->price_per_unit = values(i);
     }
@@ -165,6 +169,10 @@ void Society::set_product_prices() {
 
 std::vector<Product *>& Society::get_products() {
     return products;
+}
+
+std::vector<Product *>& Society::get_goods() {
+    return goods;
 }
 
 std::vector<Distributor *>& Society::get_distributors() {

--- a/Agent-Based Simulation/src/Society.cpp
+++ b/Agent-Based Simulation/src/Society.cpp
@@ -23,8 +23,6 @@ Society * Society::get_instance() {
 
 Society::Society() {
     set_initial_products();
-    // note: no way to assign goods to producers or suppliers
-    // to distributors yet
     for (int i = 0; i < STARTING_NUM_PRODUCERS; i++) {
         Producer * producer = new Producer({goods[i %
                 STARTING_NUM_PRODUCTS]});
@@ -37,7 +35,6 @@ Society::Society() {
         distributors.push_back(distributor);
         firms.push_back(distributor);
     }
-    // add suppliers to firms
     for (Firm * firm : firms) {
         for (Producer * producer : producers) {
             if (producer != firm) {
@@ -45,7 +42,7 @@ Society::Society() {
             }
         }
     }
-    // people MUST come after goods and distributors are created
+    // People MUST come after products and distributors are created.
     for (int i = 0; i < STARTING_NUM_PEOPLE; i++) {
         birth_person();	
     }
@@ -70,9 +67,9 @@ void Society::set_initial_products() {
         products.push_back(new_machine);
         product_to_index[new_machine] = i;
     }
-    for (Product * good: goods) {
-        good->set_inputs(goods);
-        good->set_machines(machines);
+    for (Product * product: goods) {
+        product->set_inputs(goods);
+        product->set_machines(machines);
     }
     set_product_prices();
 }

--- a/Agent-Based Simulation/src/Society.cpp
+++ b/Agent-Based Simulation/src/Society.cpp
@@ -67,7 +67,7 @@ void Society::set_initial_products() {
         products.push_back(new_machine);
         product_to_index[new_machine] = i;
     }
-    for (Product * product: goods) {
+    for (Product * product: products) {
         product->set_inputs(goods);
         product->set_machines(machines);
     }

--- a/Agent-Based Simulation/test/run_tests.sh
+++ b/Agent-Based Simulation/test/run_tests.sh
@@ -2,6 +2,7 @@
 
 for TEST in test_*.test
 do
+    echo "* RUNNING ${TEST} ***********"
     ./${TEST}
 done
 


### PR DESCRIPTION
- Changed the name of `Society::products` to `Society::goods` to distinguish products (_goods_) that can serve as inputs (raw materials) to other products from machines.
  - Goods are kept in inventories and are re-ordered in bulk when an inventory level drops below its re-order threshold.
  - Firms hold only one of each machine, and machines are re-ordered one at a time when they reach the ends of their respective lifetimes.
  - Distributors only distribute goods.
- Propagated the name change to all concerned entities (Producer and Product).
- Kept `Society::products` as the union (or concatenation) of `goods` and `machines`.
- Continued to use `Society::products` for the input-output matrix in order to compute initial prices, including the prices of machines.
- Added logic to the `Producer` constructor (but  not to that of either `Distributor` or `Firm`) to add initial machines to the `machines` vector according to the needs of products in the initial catalogue.  Producers are assumed to need machines to make their initial (and later) products, whereas distributors, for now, are not.

Resolves #94 