### PR TITLE
Emit JSON traces to `stdout`

### DIFF
--- a/Agent-Based Simulation/header/Constants.h
+++ b/Agent-Based Simulation/header/Constants.h
@@ -2,6 +2,8 @@
 
 #include <cmath>
 
+const unsigned int NUM_SIM_RUNS = 10;
+
 const int DAY = 24;
 const int WEEK = DAY * 7;
 const int MONTH = DAY * 30;

--- a/Agent-Based Simulation/header/Firm.h
+++ b/Agent-Based Simulation/header/Firm.h
@@ -58,7 +58,7 @@ struct Order {
 struct DemandSignal {
     Product * product;
     int quantity;
-    int timestep;
+    unsigned int timestep;
 };
 
 class Firm : public Agent {

--- a/Agent-Based Simulation/header/Logger.h
+++ b/Agent-Based Simulation/header/Logger.h
@@ -75,7 +75,7 @@ class Logger {
                 const unsigned int id,
                 const Tuple& values
                 );
-        static void trace(
+        static void json(
                 const int time_step,
                 const Client client,
                 std::string label,

--- a/Agent-Based Simulation/header/Sim.h
+++ b/Agent-Based Simulation/header/Sim.h
@@ -4,27 +4,35 @@
 #include <string>
 #include <vector>
 
+#include "Constants.h"
 #include "Society.h"
 
-class Sim {
-  public:
-	static std::random_device rd;
-	static std::mt19937 gen;
-    Sim();
-    static bool is_trace_logging();
-    static bool is_writing_data();
-    static bool is_using_db();
-    static void set_trace_logging(bool should_log);
-    static void set_write_data(bool should_log);
-    static void set_using_db(bool should_log);
-	static int get_current_time_step();
-    void time_step();
-    void run(int time_steps);
+struct SimArgs {
+    unsigned int time_steps = NUM_SIM_RUNS;
+    bool trace = false;
+    bool csv = false;
+    bool db = false;
+    bool json = false;
+};
 
-  private:
-    static bool use_db;
-    static bool trace_logging;
-    static bool write_data;
-    static int current_time_step;
-    Society * society;
+class Sim {
+    public:
+        static Sim& get_instance();
+        static void run(SimArgs& args);
+        static bool does_trace();
+        static bool does_csv();
+        static bool does_db();
+        static bool does_json();
+        static unsigned int get_current_time_step();
+        static std::random_device& get_random_device();
+        static std::mt19937& get_random_generator();
+        void set_params(SimArgs& args);
+    private:
+        Sim();
+        void run();
+        SimArgs args;
+        std::random_device rd;
+        std::mt19937 gen;
+        unsigned int current_time_step;
+        Society * society;
 };

--- a/Agent-Based Simulation/header/Sim.h
+++ b/Agent-Based Simulation/header/Sim.h
@@ -9,7 +9,6 @@
 
 struct SimArgs {
     unsigned int time_steps = NUM_SIM_RUNS;
-    bool trace = false;
     bool csv = false;
     bool db = false;
     bool json = false;
@@ -19,7 +18,6 @@ class Sim {
     public:
         static Sim& get_instance();
         static void run(SimArgs& args);
-        static bool does_trace();
         static bool does_csv();
         static bool does_db();
         static bool does_json();

--- a/Agent-Based Simulation/header/Society.h
+++ b/Agent-Based Simulation/header/Society.h
@@ -26,7 +26,7 @@ class Society : public Agent {
         std::vector<Distributor *>& get_distributors();
         std::vector<Person *>& get_unemployed_people();
         void retire_person(Person * person);
-        int get_current_work_hours_daily();
+        unsigned int get_current_work_hours_daily();
         int get_current_work_days_weekly();
         int get_initial_account();
         std::vector<Producer *>& get_producers();
@@ -56,7 +56,7 @@ class Society : public Agent {
         std::vector<Distributor *> distributors;
         std::unordered_map<Product *, std::vector<Distributor *>>
             product_to_distributors;
-        int current_work_hours_daily = INITIAL_WORK_HOURS_DAILY;
+        unsigned int current_work_hours_daily = INITIAL_WORK_HOURS_DAILY;
 		int current_work_days_weekly = INITIAL_WORK_DAYS_WEEKLY;
         std::vector<Person *> unemployed_people;
         double initial_account;

--- a/Agent-Based Simulation/src/Distributor.cpp
+++ b/Agent-Based Simulation/src/Distributor.cpp
@@ -61,15 +61,12 @@ bool Distributor::try_sell_goods(Product& product, int quantity, Person * person
         std::cerr << "No consumer good for product " << product.product_name << std::endl;
         return false;
     }
-
     add_demand_signal(&product, quantity);
-
     int available = catalog.count(&product) ? inventory[&product] : 0;
     if (available < quantity) {
         log_shortfall(product.product_name, quantity - available);
         return false;
     }
-
     double cost = quantity * consumer_good->price_per_unit;
     if (!person->charge(cost)) {
         std::cerr << "Person cannot afford " << quantity
@@ -77,11 +74,11 @@ bool Distributor::try_sell_goods(Product& product, int quantity, Person * person
             << cost << std::endl;
         return false;
     } 
-
     Plan * plan = product_to_plan[&product];
     plan->outgoing_units_consumed += quantity;
     plan->prd += cost;
     inventory[&product] -= quantity;
+    return true;
 }
 
 std::unordered_set<Product *> Distributor::get_products_to_reorder() {

--- a/Agent-Based Simulation/src/Firm.cpp
+++ b/Agent-Based Simulation/src/Firm.cpp
@@ -416,7 +416,7 @@ void Firm::log_reorder(std::string product_name, int quantity) {
 void Firm::log_accepted_order(std::string product_name, int requested_turnaround_time) {
     Logger::get_instance()->log(
             Logger::FIRM,
-            "accepted order",
+            "accepted_order",
             id,
             product_name,
             requested_turnaround_time

--- a/Agent-Based Simulation/src/Logger.cpp
+++ b/Agent-Based Simulation/src/Logger.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <stdexcept>
-#include <type_traits>
 
 #include "Constants.h"
 #include "Firm.h"

--- a/Agent-Based Simulation/src/Logger.cpp
+++ b/Agent-Based Simulation/src/Logger.cpp
@@ -10,7 +10,7 @@
 #include "sqlite3.h"
 
 Logger::Logger() {
-    if (Sim::is_using_db()) {
+    if (Sim::does_db()) {
         int return_code = sqlite3_open(LOG_FILE, &db);
         if (return_code) {
             throw std::runtime_error("Dztabase connection failure");
@@ -91,10 +91,10 @@ void Logger::log_impl(
         const Tuple& values
         ) {
     int time_step = Sim::get_current_time_step();
-    if (Sim::is_trace_logging()) {
+    if (Sim::does_trace()) {
         Logger::trace(time_step, client, label, id, values);
     }
-    if (Sim::is_using_db()) {
+    if (Sim::does_db()) {
         log_to_db(time_step, client, label, id, values);
     }
     data[client][label][id][time_step] = values;

--- a/Agent-Based Simulation/src/Logger.cpp
+++ b/Agent-Based Simulation/src/Logger.cpp
@@ -91,16 +91,18 @@ void Logger::log_impl(
         const Tuple& values
         ) {
     int time_step = Sim::get_current_time_step();
-    if (Sim::does_trace()) {
-        Logger::trace(time_step, client, label, id, values);
+    if (Sim::does_json()) {
+        Logger::json(time_step, client, label, id, values);
     }
     if (Sim::does_db()) {
         log_to_db(time_step, client, label, id, values);
     }
-    data[client][label][id][time_step] = values;
+    if (Sim::does_csv()) {
+        data[client][label][id][time_step] = values;
+    }
 }
 
-void Logger::trace(
+void Logger::json(
         const int time_step,
         const Client client,
         std::string label,
@@ -110,21 +112,25 @@ void Logger::trace(
     if (client >= ERROR) {
         throw std::invalid_argument("Logging client does not exist");
     }
-    std::cout << "[" << time_step << "] ";
-    std::cout << clients[client] << "_" << id << ": ";
-    std::cout << label << " - ";
+    std::cout << "{\"t\":" << time_step << "," <<
+        "\"client\":\"" << clients[client] << "\"," <<
+        "\"id\":" << id << "," <<
+        "\"label\":\"" << label << "\"," <<
+        "\"values\":[";
     auto visitor = [](auto&& arg) {
         Logger::trace_tuple(arg);
     };
     std::visit(visitor, values);
-    std::cout << std::endl;
+    std::cout << "]}" << std::endl;
 }
 
 template<typename TupleT>
 void Logger::trace_tuple(const TupleT& values) {
+    static int count = 0;
     std::apply([](auto&& ... arg) {
-            ((std::cout << arg << " "), ...);
+            ((std::cout << (count++ ? "," : "") << arg), ...);
             }, values);
+    count = 0;
 }
 
 template<typename TupleT>

--- a/Agent-Based Simulation/src/Logger.cpp
+++ b/Agent-Based Simulation/src/Logger.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <stdexcept>
+#include <type_traits>
 
 #include "Constants.h"
 #include "Firm.h"
@@ -67,7 +68,8 @@ void Logger::log(
         const std::string name,
         const int quantity
         ) {
-    TupleStringInt tuple = std::make_tuple(name, quantity);
+    const std::string name_s = std::string("\"") + name + "\"";
+    TupleStringInt tuple = std::make_tuple(name_s, quantity);
     log_impl(client, label, id, tuple);
 }
 
@@ -78,7 +80,8 @@ void Logger::log(
         const std::string name,
         const double measure
         ) {
-    TupleStringDouble tuple = std::make_tuple(name, measure);
+    const std::string name_s = std::string("\"") + name + "\"";
+    TupleStringDouble tuple = std::make_tuple(name_s, measure);
     log_impl(client, label, id, tuple);
 }
 
@@ -128,7 +131,7 @@ template<typename TupleT>
 void Logger::trace_tuple(const TupleT& values) {
     static int count = 0;
     std::apply([](auto&& ... arg) {
-            ((std::cout << (count++ ? "," : "") << arg), ...);
+            ((std::cout << (count++ ? "," : "") << arg), ...); count++;
             }, values);
     count = 0;
 }

--- a/Agent-Based Simulation/src/Person.cpp
+++ b/Agent-Based Simulation/src/Person.cpp
@@ -26,7 +26,7 @@ Person::Person(Society * society):
                 PERSON_SHOPPING_PERIOD / 2, PERSON_SHOPPING_OFFSET_STDDEV
                 );
     shopping_offset =
-        (((int) shopping_dist(Sim::gen)) +
+        (((int) shopping_dist(Sim::get_random_generator())) +
          PERSON_SHOPPING_PERIOD) % PERSON_SHOPPING_PERIOD;
 
     static std::normal_distribution<>
@@ -35,15 +35,15 @@ Person::Person(Society * society):
     for (int i = 0; i < Person::NUM_ABILITIES; i++) {
         all_abilities.push_back((Person::Ability) i);
     }
-    std::shuffle(all_abilities.begin(), all_abilities.end(), Sim::gen);
+    std::shuffle(all_abilities.begin(), all_abilities.end(), Sim::get_random_generator());
     all_abilities.resize(PERSON_ABILITY_COUNT_MAX);
     for (Person::Ability ability : all_abilities) {
-        abilities[ability] = std::max(0.0, ability_dist(Sim::gen));
+        abilities[ability] = std::max(0.0, ability_dist(Sim::get_random_generator()));
         static std::normal_distribution<>
             dist(1, PERSON_FREQUENCY_MULTIPLIER_STDDEV);
         for (Product * p : society->get_goods()) {
             purchase_frequencies[p] =
-                p->mean_consumption_frequency * std::abs(dist(Sim::gen));
+                p->mean_consumption_frequency * std::abs(dist(Sim::get_random_generator()));
         }
         account = society->get_initial_account();
     }
@@ -51,13 +51,13 @@ Person::Person(Society * society):
     std::shuffle(
             ranked_distributors.begin(),
             ranked_distributors.end(),
-            Sim::gen
+            Sim::get_random_generator()
             );
     static std::normal_distribution<>
         dist(1, PERSON_FREQUENCY_MULTIPLIER_STDDEV);
     for (Product * p : society->get_goods()) {
         purchase_frequencies[p] =
-            p->mean_consumption_frequency * std::abs(dist(Sim::gen));
+            p->mean_consumption_frequency * std::abs(dist(Sim::get_random_generator()));
     }
 }
 
@@ -135,7 +135,7 @@ void Person::shop() {
     double total_price = 0.0;
     for (std::pair<Product *, double> p : purchase_frequencies) {
         ideal_purchase_quantities[p.first] =
-            p.second * PERSON_SHOPPING_PERIOD * std::abs(dist(Sim::gen));
+            p.second * PERSON_SHOPPING_PERIOD * std::abs(dist(Sim::get_random_generator()));
         total_price += ideal_purchase_quantities[p.first] * 
             society->get_consumer_good(p.first)->price_per_unit;
     }
@@ -153,7 +153,7 @@ void Person::shop() {
 bool Person::will_retire() {
     static std::uniform_real_distribution<> dist(0, 1);
     if (age >= GUARANTEED_RETIREMENT_AGE) { return true; }
-    return dist(Sim::gen) < RANDOM_RETIREMENT_CHANCE;
+    return dist(Sim::get_random_generator()) < RANDOM_RETIREMENT_CHANCE;
 }
 
 void Person::retire() {
@@ -163,10 +163,10 @@ void Person::retire() {
 void Person::update_health_status() {
 	static std::uniform_real_distribution<> dist(0, 1);
 	if (health_status == HEALTHY &&
-		dist(Sim::gen) < 1 - pow(1 - DAILY_SICKNESS_CHANCE, 1.0 / DAY)) {
+		dist(Sim::get_random_generator()) < 1 - pow(1 - DAILY_SICKNESS_CHANCE, 1.0 / DAY)) {
 		health_status = UNHEALTHY;
 	} else if (health_status == UNHEALTHY &&
-	   dist(Sim::gen) < 1 - pow(1 - DAILY_RECOVERY_CHANCE, 1.0 / DAY)) {
+	   dist(Sim::get_random_generator()) < 1 - pow(1 - DAILY_RECOVERY_CHANCE, 1.0 / DAY)) {
 		health_status = HEALTHY;
 	} 
 }

--- a/Agent-Based Simulation/src/Product.cpp
+++ b/Agent-Based Simulation/src/Product.cpp
@@ -13,37 +13,37 @@ struct Machine;
 Product::Product(const std::string name) : product_name{name} {
     static std::uniform_int_distribution<>
         order_size_dist(PRODUCT_ORDER_SIZE_MIN, PRODUCT_ORDER_SIZE_MAX);
-    order_size = order_size_dist(Sim::gen);
+    order_size = order_size_dist(Sim::get_random_generator());
     static std::uniform_int_distribution<>
         living_labor_dist(
                 PRODUCT_LABOR_PER_UNIT_MIN,
                 PRODUCT_LABOR_PER_UNIT_MAX
                 );
-    living_labor_per_unit = (double)living_labor_dist(Sim::gen);
+    living_labor_per_unit = (double)living_labor_dist(Sim::get_random_generator());
     for (int i = 0; i < Person::NUM_ABILITIES; i++) {
         required_abilities.push_back((Person::Ability) i);
     }
-    std::shuffle(required_abilities.begin(), required_abilities.end(), Sim::gen);
+    std::shuffle(required_abilities.begin(), required_abilities.end(), Sim::get_random_generator());
     static std::uniform_int_distribution<>
         ability_count_dist(1, PRODUCT_ABILITY_COUNT_MAX);
-    required_abilities.resize(ability_count_dist(Sim::gen));
+    required_abilities.resize(ability_count_dist(Sim::get_random_generator()));
     static std::uniform_real_distribution<>
         frequency_dist(
                 PRODUCT_CONSUMPTION_FREQUENCY_MIN,
                 PRODUCT_CONSUMPTION_FREQUENCY_MAX
                 );
-    mean_consumption_frequency = frequency_dist(Sim::gen);
+    mean_consumption_frequency = frequency_dist(Sim::get_random_generator());
 }
 
 void Product::set_inputs(std::vector<Product *>& goods) {
     static std::uniform_int_distribution<>
         num_inputs_dist(PRODUCT_NUM_INPUTS_MIN, PRODUCT_NUM_INPUTS_MAX);
-    const std::size_t num_inputs = num_inputs_dist(Sim::gen);
+    const std::size_t num_inputs = num_inputs_dist(Sim::get_random_generator());
     std::uniform_int_distribution<>
         product_input_index_dist(0, goods.size() - 1);
     std::set<int> indices;
     while (indices.size() < num_inputs) {
-        indices.insert(product_input_index_dist(Sim::gen));
+        indices.insert(product_input_index_dist(Sim::get_random_generator()));
     }
     static std::uniform_real_distribution<>
         input_per_unit_dist(
@@ -51,19 +51,19 @@ void Product::set_inputs(std::vector<Product *>& goods) {
                 PRODUCT_INPUT_PER_UNIT_MAX
                 );
     for (int index : indices) {
-        inputs_per_unit[goods[index]] = input_per_unit_dist(Sim::gen);
+        inputs_per_unit[goods[index]] = input_per_unit_dist(Sim::get_random_generator());
     }
 }
 
 void Product::set_machines(std::vector<Machine*> machines) {
     static std::uniform_int_distribution<>
         num_machines_dist(PRODUCT_NUM_MACHINES_MIN, PRODUCT_NUM_MACHINES_MAX);
-    const std::size_t num_machines = num_machines_dist(Sim::gen);
+    const std::size_t num_machines = num_machines_dist(Sim::get_random_generator());
     std::uniform_int_distribution<>
         product_machine_index_dist(0, machines.size() - 1);
     std::set<int> indices;
     while (indices.size() < num_machines) {
-        indices.insert(product_machine_index_dist(Sim::gen));
+        indices.insert(product_machine_index_dist(Sim::get_random_generator()));
     }
     for (int index : indices) {
         machines_needed.push_back(machines[index]);

--- a/Agent-Based Simulation/src/Sim.cpp
+++ b/Agent-Based Simulation/src/Sim.cpp
@@ -2,57 +2,60 @@
 #include "Logger.h"
 #include "Sim.h"
 
-Sim::Sim() {
-	society = Society::get_instance();
+Sim& Sim::get_instance() {
+    static Sim sim;
+    return sim;
 }
 
-bool Sim::is_trace_logging() {
-    return trace_logging;
+void Sim::run(SimArgs& args) {
+    get_instance().set_params(args);
+    get_instance().run();
 }
 
-bool Sim::is_writing_data() {
-    return write_data;
+Sim::Sim() :
+    gen{rd()},
+    society{Society::get_instance()}
+{}
+
+bool Sim::does_trace() {
+    return get_instance().args.trace;
 }
 
-bool Sim::is_using_db() {
-    return use_db;
+bool Sim::does_csv() {
+    return get_instance().args.csv;
 }
 
-void Sim::set_trace_logging(bool should_trace) {
-    trace_logging = should_trace; 
+bool Sim::does_db() {
+    return get_instance().args.db;
 }
 
-void Sim::set_write_data(bool should_write) {
-    write_data = should_write; 
+bool Sim::does_json() {
+    return get_instance().args.json;
 }
 
-void Sim::set_using_db(bool should_use_db) {
-    use_db = should_use_db; 
+void Sim::set_params(SimArgs& args) {
+    this->args = args;
 }
 
-int Sim::get_current_time_step() {
-	return current_time_step;
+std::random_device& Sim::get_random_device() {
+    return get_instance().rd;
 }
 
-void Sim::run(int time_steps) {
-    for (std::size_t i = 0; i < time_steps; ++i) {
+std::mt19937& Sim::get_random_generator() {
+    return get_instance().gen;
+}
+
+unsigned int Sim::get_current_time_step() {
+	return get_instance().current_time_step;
+}
+
+void Sim::run() {
+    for (std::size_t i = 0; i < args.time_steps; ++i) {
         society->on_time_step();
         current_time_step++;
     }
-    if (Sim::is_writing_data()) {
+    if (args.csv) {
         Logger::get_instance()->write_data();
     }
 }
-
-int Sim::current_time_step = 0;
-
-bool Sim::trace_logging = false;
-
-bool Sim::write_data = false;
-
-bool Sim::use_db = false;
-
-std::random_device Sim::rd;
-
-std::mt19937 Sim::gen(Sim::rd());
 

--- a/Agent-Based Simulation/src/Sim.cpp
+++ b/Agent-Based Simulation/src/Sim.cpp
@@ -8,13 +8,13 @@ Sim& Sim::get_instance() {
 }
 
 void Sim::run(SimArgs& args) {
-    get_instance().set_params(args);
-    get_instance().run();
+    Sim& sim = get_instance();
+    sim.set_params(args);
+    sim.run();
 }
 
 Sim::Sim() :
-    gen{rd()},
-    society{Society::get_instance()}
+    gen{rd()}
 {}
 
 bool Sim::does_trace() {
@@ -50,6 +50,7 @@ unsigned int Sim::get_current_time_step() {
 }
 
 void Sim::run() {
+    society = Society::get_instance();
     for (std::size_t i = 0; i < args.time_steps; ++i) {
         society->on_time_step();
         current_time_step++;

--- a/Agent-Based Simulation/src/Sim.cpp
+++ b/Agent-Based Simulation/src/Sim.cpp
@@ -17,10 +17,6 @@ Sim::Sim() :
     gen{rd()}
 {}
 
-bool Sim::does_trace() {
-    return get_instance().args.trace;
-}
-
 bool Sim::does_csv() {
     return get_instance().args.csv;
 }
@@ -59,4 +55,3 @@ void Sim::run() {
         Logger::get_instance()->write_data();
     }
 }
-

--- a/Agent-Based Simulation/src/Society.cpp
+++ b/Agent-Based Simulation/src/Society.cpp
@@ -222,7 +222,7 @@ std::vector<Person *>& Society::get_unemployed_people() {
     return unemployed_people;
 }
 
-int Society::get_current_work_hours_daily() {
+unsigned int Society::get_current_work_hours_daily() {
     return current_work_hours_daily;
 }
 

--- a/Agent-Based Simulation/src/Society.cpp
+++ b/Agent-Based Simulation/src/Society.cpp
@@ -74,7 +74,7 @@ void Society::on_time_step() {
 void Society::set_initial_products() {
     std::size_t i = 0;
     for (; i < STARTING_NUM_PRODUCTS; ++i) {
-        Product * new_product = new Product("Product " + std::to_string(i));
+        Product * new_product = new Product("Product_" + std::to_string(i));
         new_product->id = i;
         goods.push_back(new_product);
         products.push_back(new_product);

--- a/Agent-Based Simulation/src/Society.cpp
+++ b/Agent-Based Simulation/src/Society.cpp
@@ -85,7 +85,7 @@ void Society::set_initial_products() {
     for (std::size_t j = 0; j < STARTING_NUM_MACHINES; ++j, ++i) {
         Machine * new_machine = new Machine(
                 "Machine " + std::to_string(i),
-                machine_lifetime_dist(Sim::gen)
+                machine_lifetime_dist(Sim::get_random_generator())
                 );
         machines.push_back(new_machine);
         products.push_back(new_machine);

--- a/Agent-Based Simulation/src/main.cpp
+++ b/Agent-Based Simulation/src/main.cpp
@@ -9,8 +9,6 @@ void print_usage() {
         std::endl;
     std::cout << "\t-d: Store logged data in a SQLite database file called "
         "sim.db." << std::endl;
-    std::cout << "\t-t: Write log traces to stdin throughout execution." <<
-        std::endl;
     std::cout << "\t-j: Write log traces to stdin in JSON format throughout "
         "execution." << std::endl;
     std::cout << "\tYou can combine any arguments except -n, e.g., -ct to "
@@ -32,9 +30,6 @@ void set_params(int argc, const char ** argv, SimArgs& args) {
             } else {
                 while (argv[i][j]) {
                     switch (argv[i][j]) {
-                        case 't':
-                            args.trace = true;
-                            break;
                         case 'c':
                             args.csv = true;
                             break;

--- a/Agent-Based Simulation/src/main.cpp
+++ b/Agent-Based Simulation/src/main.cpp
@@ -2,24 +2,62 @@
 
 #include "Sim.h"
 
-bool arg_present(
-        const std::string arg,
-        const int argc,
-        const char ** const argv
-        ) {
+void print_usage() {
+    std::cout << "Usage: sim [<args> ...]" << std::endl;
+    std::cout << "\t-n N: Run the simulation for N time steps." << std::endl;
+    std::cout << "\t-c: Write CSV log files at the end of simulation." <<
+        std::endl;
+    std::cout << "\t-d: Store logged data in a SQLite database file called "
+        "sim.db." << std::endl;
+    std::cout << "\t-t: Write log traces to stdin throughout execution." <<
+        std::endl;
+    std::cout << "\t-j: Write log traces to stdin in JSON format throughout "
+        "execution." << std::endl;
+    std::cout << "\tYou can combine any arguments except -n, e.g., -ct to "
+        "print traces _and_ write CSV logs." << std::endl;
+}
+
+void set_params(int argc, const char ** argv, SimArgs& args) {
     for (int i = 0; i < argc; ++i) {
-        if ("--" + arg == argv[i]) {
-            return true;
+        unsigned j = 0;
+        if (argv[i][j] == '-') {
+            ++j;
+            if (argv[i][j] == 'n') {
+                ++i;
+                long num_time_steps = strtol(argv[i], NULL, 10);
+                if (num_time_steps) {
+                    args.time_steps = static_cast<unsigned int>(num_time_steps);
+                }
+                continue;
+            } else {
+                while (argv[i][j]) {
+                    switch (argv[i][j]) {
+                        case 't':
+                            args.trace = true;
+                            break;
+                        case 'c':
+                            args.csv = true;
+                            break;
+                        case 'd':
+                            args.db = true;
+                            break;
+                        case 'j':
+                            args.json = true;
+                            break;
+                        case 'h':
+                            print_usage();
+                            exit(EXIT_SUCCESS);
+                    }
+                    ++j;
+                }
+            }
         }
     }
-    return false;
 }
 
 int main(int argc, const char ** argv) {
-	Sim simulation;
-    simulation.set_trace_logging(arg_present("trace", argc, argv));
-    simulation.set_write_data(arg_present("write", argc, argv));
-    simulation.set_using_db(arg_present("db", argc, argv));
-    simulation.run(1000);
+    SimArgs args;
+    set_params(argc, argv, args);
+    Sim::run(args);
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Replace the printing of ad-hoc traces with the emission of JSON entries for use in real-time graphing.

Example used for testing:
```
{"t":10,"client":"Society","id":1023,"label":"phony","values":[test,3.14159]}
```
(As of now, nothing in the code logs more than one value at a time, so I created the above logging instance at the end of a simulation run just for testing and then removed it. Hence the "phony" label.)

Resolves #141 