### PR TITLE
Compare unsigned types with like types only

### DIFF
--- a/Agent-Based Simulation/header/Distributor.h
+++ b/Agent-Based Simulation/header/Distributor.h
@@ -25,7 +25,6 @@ class Distributor : public Firm {
     int get_inventory(Product * product) override;
     
   private:
-    int get_pending_input_inventory(Product * product);
     std::unordered_set<Product *> get_products_to_reorder() override;
     std::unordered_map<Product *, int> input_inventory;
     std::unordered_map<Product *, Plan *> product_to_plan;

--- a/Agent-Based Simulation/header/Firm.h
+++ b/Agent-Based Simulation/header/Firm.h
@@ -97,7 +97,7 @@ class Firm : public Agent {
     bool remove_input_inventory(Product * product, int quantity);
     void add_input_inventory(Product * product, int quantity);
     double get_reorder_threshold(Product * product);
-    virtual int get_pending_input_inventory(Product * product);
+    int get_pending_input_inventory(Product * product);
     void reorder_input_product_to_threshold(
         Product * product, 
         double threshold,

--- a/Agent-Based Simulation/makefile
+++ b/Agent-Based Simulation/makefile
@@ -9,7 +9,7 @@ GRAPH_DIR = ${DOCS_DIR}/graphs
 TEST_SRCS = $(wildcard ${TEST_DIR}/*.cpp)
 TEST_EXECS = $(patsubst %.cpp, %.test, ${TEST_SRCS})
 APP = ${BIN_DIR}/sim
-FLAGS = -Wall -Iheader -std=c++17 -g
+FLAGS = -Wall -Wsign-compare -Iheader -std=c++17 -g
 PLOT_SRC = ${GRAPH_DIR}/plot_producer_distributor_transactions.cpp
 PLOT_APP = ${BIN_DIR}/plot_producer_distributor_transactions
 MATPLOT_INCLUDE ?= ${HOME}/.local/include

--- a/Agent-Based Simulation/src/Distributor.cpp
+++ b/Agent-Based Simulation/src/Distributor.cpp
@@ -89,14 +89,6 @@ bool Distributor::try_sell_goods(Product& product, int quantity, Person * person
     return true;
 }
 
-int Distributor::get_pending_input_inventory(Product * product) {
-    int pending_inventory = input_inventory[product];
-    for (Order * order : product_to_outbound_orders[product]) {
-        pending_inventory += order->quantity;
-    }
-    return pending_inventory;
-}
-
 std::unordered_set<Product *> Distributor::get_products_to_reorder() {
     return catalog;
 }

--- a/Agent-Based Simulation/src/Firm.cpp
+++ b/Agent-Based Simulation/src/Firm.cpp
@@ -201,11 +201,11 @@ void Firm::assign_workers(
             });
 
     int workers_left = predict_workers_needed(draft_plan->order);
-    for (int i = 0; i < workers.size() && workers_left > 0; i++) {
+    for (unsigned int i = 0; i < workers.size() && workers_left > 0; ++i) {
         draft_plan->workers.push_back(workers[i]);
         workers_left--;
     }
-    for (int i = 0; i < society->get_unemployed_people().size() && workers_left > 0; i++) {
+    for (unsigned int i = 0; i < society->get_unemployed_people().size() && workers_left > 0; i++) {
         draft_plan->workers.push_back(society->get_unemployed_people()[i]);
         workers_left--;
     }

--- a/Agent-Based Simulation/src/Society.cpp
+++ b/Agent-Based Simulation/src/Society.cpp
@@ -154,7 +154,7 @@ double get_max_eigenvalue(Eigen::MatrixXd& io_matrix) {
     Eigen::EigenSolver<Eigen::MatrixXd> eigen_solver(io_matrix, false);
     Eigen::VectorXcd eigenvalues = eigen_solver.eigenvalues();
     double max_eigenvalue = 0.0;
-    for (size_t i = 0; i < eigenvalues.size(); ++i) {
+    for (size_t i = 0; i < static_cast<unsigned long>(eigenvalues.size()); ++i) {
         if (eigenvalues(i).real() > max_eigenvalue &&
                 !eigenvalues(i).imag()) {
             max_eigenvalue = eigenvalues(i).real();


### PR DESCRIPTION
I changed signed to unsigned types in a few for-loops. Surprisingly, `Eigen::VectorXcd::size` returns `Index` (aka `long`), so, to compare it with `size_t`, I cast the former to `unsigned long`.

I also removed the duplicate implementation of `Distributor::get_pending_input_inventory`, which `Distributor` should simply inherit unchanged form `Firm` (without overriding), and removed the `virtual` qualifier accordingly.

Resolves #153 