### PR TITLE
Call `Firm::check_and_reorder_inputs` only when an input inventory level can drop

### DIFF
--- a/Agent-Based Simulation/header/Firm.h
+++ b/Agent-Based Simulation/header/Firm.h
@@ -103,6 +103,7 @@ class Firm : public Agent {
         int pending_inventory
     );
     void check_and_reorder_inputs();
+    void check_and_reorder_input(Product * product);
 
 	int predict_workers_needed(Order * order);
     void assign_workers(

--- a/Agent-Based Simulation/src/Distributor.cpp
+++ b/Agent-Based Simulation/src/Distributor.cpp
@@ -86,6 +86,7 @@ bool Distributor::try_sell_goods(Product& product, int quantity, Person * person
     plan->outgoing_units_consumed += quantity;
     plan->prd += cost;
     input_inventory[&product] -= quantity;
+    check_and_reorder_input(&product);
     return true;
 }
 

--- a/Agent-Based Simulation/src/Firm.cpp
+++ b/Agent-Based Simulation/src/Firm.cpp
@@ -93,10 +93,6 @@ bool Firm::remove_input_from_inventory(Product * product, int quantity) {
     return true;
 }
 
-void Firm::add_input_inventory(Product * product, int quantity) {
-    input_inventory[product] += quantity;
-}
-
 Producer * Firm::send_order(Order * order) {
     int order_time = INT_MAX;
     Producer * chosen_producer = nullptr;
@@ -172,14 +168,17 @@ void Firm::reorder_input_product_to_threshold(
 
 void Firm::check_and_reorder_inputs() {
     for (std::pair<Product *, int> stockpile : input_inventory) {
-        Product * input_product = stockpile.first;
+        check_and_reorder_input(stockpile.first);
     }
 }
-        double threshold = get_reorder_threshold(input_product);
-        int pending_inventory = get_pending_input_inventory(input_product);
-        if (pending_inventory < threshold) {
-            reorder_input_product_to_threshold(input_product, threshold, pending_inventory);
-        }
+
+void Firm::check_and_reorder_input(Product * product) {
+    double threshold = get_reorder_threshold(product);
+    int pending_inventory = get_pending_input_inventory(product);
+    if (pending_inventory < threshold) {
+        reorder_input_product_to_threshold(product, threshold, pending_inventory);
+    }
+}
 
 int Firm::predict_workers_needed(Order * order) {
     return std::ceil(

--- a/Agent-Based Simulation/src/Producer.cpp
+++ b/Agent-Based Simulation/src/Producer.cpp
@@ -122,7 +122,7 @@ void Producer::start_plan(Plan * plan) {
         int required_input = static_cast<int>(
             std::ceil(input.second * plan->order->quantity)
             );
-        remove_input_inventory(input.first, required_input);
+        remove_input_from_inventory(input.first, required_input);
 	}
     pooled_input_value_account += plan->raw_materials;
     plan->raw_materials = 0;


### PR DESCRIPTION
With this change, instead of checking the input inventory on every time step for every firm _and again_ for every plan of every producer, we check, and reorder if necessary, only
- When a producer removes products from its input inventory at the start fo a plan
- When a customer buys a product from a distributor.
In the latter case, we only check the level (and possibly reorder) for the product in question.

Resolves #164 