### PR TITLE
242 log random generation seed

### DIFF
--- a/header/Logger.h
+++ b/header/Logger.h
@@ -26,6 +26,7 @@ class Logger {
             PERSON,
             PRODUCER,
             PRODUCT,
+            SIMULATION,
             SOCIETY,
             ERROR
         };
@@ -58,6 +59,7 @@ void Logger::log(
         "Person",
         "Producer",
         "Product",
+        "Simulation",
         "Society"
     };
     int time_step = Sim::get_current_time_step();

--- a/header/Sim.h
+++ b/header/Sim.h
@@ -55,6 +55,7 @@ class Sim {
         void run();
         SimArgs args;
         std::random_device rd;
+        unsigned int seed = 0;
         std::mt19937 gen;
         int current_time_step;
         Society * society;

--- a/header/Sim.h
+++ b/header/Sim.h
@@ -47,7 +47,6 @@ class Sim {
         static std::string get_initial_price_mode();
         static bool does_json();
         static int get_current_time_step();
-        static std::random_device& get_random_device();
         static std::mt19937& get_random_generator();
         void set_params(SimArgs& args);
     private:

--- a/src/Distributor.cpp
+++ b/src/Distributor.cpp
@@ -44,8 +44,8 @@ void Distributor::add_to_catalog(Product * product) {
         * Sim::get_num_people() 
         / Sim::get_num_distributors();
     static std::normal_distribution<double> demand_mult(1.0, DEMAND_PREDICTION_VARIANCE);
-    demands[good] *= demand_mult(Sim::get_random_device());
-    demands[consumer_good] *= demand_mult(Sim::get_random_device());
+    demands[good] *= demand_mult(Sim::get_random_generator());
+    demands[consumer_good] *= demand_mult(Sim::get_random_generator());
     input_inventory[good] = demands[good] * FIRM_STOCKPILE_DURATION;
     input_inventory[consumer_good] = demands[consumer_good] * FIRM_STOCKPILE_DURATION;
     log_inventory_level(good, input_inventory[good]);

--- a/src/Producer.cpp
+++ b/src/Producer.cpp
@@ -49,7 +49,7 @@ void Producer::add_to_catalog(Product * product) {
     }
     static std::normal_distribution<double> demand_mult(1.0, DEMAND_PREDICTION_VARIANCE);
     for (std::pair<Product * const, double>& demand : demands) {
-        demand.second *= demand_mult(Sim::get_random_device());
+        demand.second *= demand_mult(Sim::get_random_generator());
         input_inventory[demand.first] = demand.second * FIRM_STOCKPILE_DURATION;
     }
     for (std::pair<Product * const, double>& stockpile : input_inventory) {

--- a/src/Sim.cpp
+++ b/src/Sim.cpp
@@ -13,10 +13,6 @@ void Sim::run(SimArgs& args) {
     sim.run();
 }
 
-Sim::Sim() :
-    gen{rd()}
-{}
-
 unsigned int Sim::get_num_people() {
     return get_instance().args.num_people;
 }
@@ -77,12 +73,8 @@ bool Sim::does_json() {
     return get_instance().args.json;
 }
 
-void Sim::set_params(SimArgs& args) {
-    this->args = args;
-    
-    if(this->args.fixed_seed) {
-        this->gen.seed(this->args.seed);
-    }
+int Sim::get_current_time_step() {
+	return get_instance().current_time_step;
 }
 
 std::random_device& Sim::get_random_device() {
@@ -93,9 +85,23 @@ std::mt19937& Sim::get_random_generator() {
     return get_instance().gen;
 }
 
-int Sim::get_current_time_step() {
-	return get_instance().current_time_step;
+void Sim::set_params(SimArgs& args) {
+    this->args = args;
+    if(this->args.fixed_seed) {
+        seed = args.seed;
+    } else {
+        seed = rd();
+    }
+    gen.seed(seed);
+    Logger::log(
+            Logger::SIMULATION,
+            0,
+            "random_seed",
+            LogPair("seed", seed)
+            );
 }
+
+Sim::Sim() {}
 
 void Sim::run() {
     society = Society::get_instance();

--- a/src/Sim.cpp
+++ b/src/Sim.cpp
@@ -77,10 +77,6 @@ int Sim::get_current_time_step() {
 	return get_instance().current_time_step;
 }
 
-std::random_device& Sim::get_random_device() {
-    return get_instance().rd;
-}
-
 std::mt19937& Sim::get_random_generator() {
     return get_instance().gen;
 }
@@ -97,7 +93,7 @@ void Sim::set_params(SimArgs& args) {
             Logger::SIMULATION,
             0,
             "random_seed",
-            LogPair("seed", seed)
+            LogPair("value", seed)
             );
 }
 


### PR DESCRIPTION
Resolves #242 

- Save the seed, either generated by the random device or passed in from the command line, as a private field of `Sim`.
- Log the seed at program start under label `random_seed` and key `value`.
- Replace every call to `get_random_device` with a call to `get_random_generator` and remove the former from `Sim`.

On the last point — it is against best practice to get random values directly from `std::random_device` and to call it repeatedly, because it is relatively quite slow and — precisely — because it makes deterministic behavior impossible, even when desired. This change should make every pseudorandom generation event reproducible if the user enters the `-e` flag with an integer value.