### PR TITLE
Fix non-determinism in Firm & optimize dependencies

### DIFF
--- a/header/Firm.h
+++ b/header/Firm.h
@@ -2,18 +2,14 @@
 
 #include <string>
 #include <tuple>
-#include <map>
-#include <set>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include <queue>
 
 #include "Agent.h"
 #include "Logger.h"
 #include "Person.h"
-
-struct ProductID {
-    bool operator()(const Product* a, const Product* b ) const;
-};
 
 struct Ability;
 struct Machine;
@@ -48,12 +44,12 @@ class Firm : public Agent {
     std::unordered_set<Person *> workers,
         standby_workers;
 	
-    std::map<Product *, double, ProductID> input_inventory;
-    std::set<Product *, ProductID> catalog;
+    std::unordered_map<Product *, double> input_inventory;
+    std::unordered_set<Product *> catalog;
     
-    std::map<Product *, double, ProductID> demands;
-    std::map<Product *, std::unordered_set<Order *>, ProductID> product_to_outbound_orders;
-    std::map<Product *, double, ProductID> recorded_living_labor_per_unit;
+    std::unordered_map<Product *, double> demands;
+    std::unordered_map<Product *, std::unordered_set<Order *>> product_to_outbound_orders;
+    std::unordered_map<Product *, double> recorded_living_labor_per_unit;
 
     std::unordered_set<Plan *> plans_in_progress;
 

--- a/header/Firm.h
+++ b/header/Firm.h
@@ -2,14 +2,18 @@
 
 #include <string>
 #include <tuple>
-#include <unordered_map>
-#include <unordered_set>
+#include <map>
+#include <set>
 #include <vector>
 #include <queue>
 
 #include "Agent.h"
 #include "Logger.h"
 #include "Person.h"
+
+struct ProductID {
+    bool operator()(const Product* a, const Product* b ) const;
+};
 
 struct Ability;
 struct Machine;
@@ -44,12 +48,13 @@ class Firm : public Agent {
     std::unordered_set<Person *> workers,
         standby_workers;
 	
-    std::unordered_map<Product *, double> input_inventory;
-    std::unordered_set<Product *> catalog;
+    std::map<Product *, double, ProductID> input_inventory;
+    std::set<Product *, ProductID> catalog;
     
-    std::unordered_map<Product *, double> demands;
-    std::unordered_map<Product *, std::unordered_set<Order *>> product_to_outbound_orders;
-    std::unordered_map<Product *, double> recorded_living_labor_per_unit;
+    std::map<Product *, double, ProductID> demands;
+    std::map<Product *, std::unordered_set<Order *>, ProductID> product_to_outbound_orders;
+    std::map<Product *, double, ProductID> recorded_living_labor_per_unit;
+
     std::unordered_set<Plan *> plans_in_progress;
 
     Producer * send_order(Order * order);

--- a/makefile
+++ b/makefile
@@ -9,7 +9,8 @@ GRAPH_DIR = ${DOCS_DIR}/graphs
 TEST_SRCS = $(wildcard ${TEST_DIR}/*.cpp)
 TEST_EXECS = $(patsubst %.cpp, %.test, ${TEST_SRCS})
 APP = ${BIN_DIR}/sim
-FLAGS = -Wall -Wsign-compare -Iheader -std=c++17 -g
+OPT_FLAG = -O2
+FLAGS = -Wall -Wsign-compare -Iheader -std=c++17 -g $(OPT_FLAG)
 PLOT_SRC = ${GRAPH_DIR}/plot_producer_distributor_transactions.cpp
 PLOT_APP = ${BIN_DIR}/plot_producer_distributor_transactions
 MATPLOT_INCLUDE ?= ${HOME}/.local/include
@@ -101,15 +102,24 @@ graphs: trace plot-tool
 clean:
 	rm -rf $(wildcard ${BIN_DIR}/*) $(wildcard ${BUILD_DIR}/*) $(wildcard ${TEST_DIR}/*.test) \
 		$(wildcard ${DATA_DIR}/*) \
-		*.gcno *.gcda *.profraw *.profdata *.info out_coverage/ test/*.gcno test/*.gcda
+		*.gcno *.gcda *.profraw *.profdata *.info out_coverage/ test/*.gcno test/*.gcda *.gcov
 
+coverage: OPT_FLAG = -O0
 coverage: FLAGS += --coverage
 coverage: clean tests
 
 score: coverage
 	cd test && ./run_tests.sh
 	@echo "Calculating coverage percentage:"
-	@lcov --ignore-errors inconsistent,range,format,corrupt,empty --capture --directory . --output-file tmp.info --quiet 2>/dev/null
-	@lcov --ignore-errors inconsistent,range,format,corrupt,empty --extract tmp.info '*/src/*' --output-file tmp.filtered.info --quiet 2>/dev/null
-	@lcov --ignore-errors inconsistent,range,format,corrupt,empty --summary tmp.filtered.info 2>/dev/null
-	@rm -f tmp.info tmp.filtered.info
+	@gcov --object-directory ${BUILD_DIR} $(filter-out ${SRC_DIR}/main.cpp, ${SRC_FILES}) > .gcov_log 2>&1
+	@awk -F'[: %]+' '/Lines executed/ { \
+		if ($$5 > 0 && $$3 != "nan") { \
+			exec += ($$3 * $$5 / 100); \
+			total += $$5; \
+		} \
+	} \
+	END { \
+		if (total > 0) \
+			printf "TOTAL PROJECT COVERAGE: %.2f%%\n", (exec / total) * 100; \
+	}' .gcov_log
+	@rm -f .gcov_log

--- a/src/Firm.cpp
+++ b/src/Firm.cpp
@@ -20,10 +20,6 @@
 #include "Sim.h"
 #include "Society.h"
 
-bool ProductID::operator()(const Product* a, const Product* b) const {
-    return a->id < b->id;
-}
-
 Firm::Firm() {
     static unsigned int unique_id = 0;
     id = unique_id++;

--- a/src/Firm.cpp
+++ b/src/Firm.cpp
@@ -20,6 +20,10 @@
 #include "Sim.h"
 #include "Society.h"
 
+bool ProductID::operator()(const Product* a, const Product* b) const {
+    return a->id < b->id;
+}
+
 Firm::Firm() {
     static unsigned int unique_id = 0;
     id = unique_id++;

--- a/src/Firm.cpp
+++ b/src/Firm.cpp
@@ -206,19 +206,11 @@ void Firm::check_and_reorder_input(Product * product) {
     }
 }
 
-void Firm::rollback_plan_inputs(
-    Plan * plan,
-    const std::vector<std::pair<Product *, double>>& deducted_inputs
-) {
-    for (
-        const std::pair<Product *, double>& deduction :
-        deducted_inputs
-    ) {
-        Product * input = deduction.first;
-        double quantity = deduction.second;
-
-        input_inventory[input] += quantity;
-        log_inventory_level(input, input_inventory[input]);
+void Firm::start_plan(Plan * plan) {
+    std::cout << "T: " << Sim::get_current_time_step() << " " <<
+        id << " " << plan->order->product->id << std::endl;
+    for (Person * worker : plan->workers) {
+        move_worker_off_standby(worker);
     }
 
     plan->inventory.clear();

--- a/src/Product.cpp
+++ b/src/Product.cpp
@@ -15,7 +15,7 @@ struct Machine;
 Product::Product() {
     static unsigned int unique_id = 0;
     id = unique_id++;
-    static std::uniform_real_distribution<>
+    std::uniform_real_distribution<>
         living_labor_dist(
                 PRODUCT_LABOR_PER_UNIT_MIN,
                 PRODUCT_LABOR_PER_UNIT_MAX
@@ -31,7 +31,7 @@ Product::Product() {
             required_abilities.end(),
             Sim::get_random_generator()
             );
-    static std::uniform_int_distribution<>
+    std::uniform_int_distribution<>
         ability_count_dist(1, PRODUCT_ABILITY_COUNT_MAX);
     required_abilities.resize(ability_count_dist(Sim::get_random_generator()));
 }
@@ -39,7 +39,7 @@ Product::Product() {
 void Product::set_inputs() {
     std::vector<Good *>& goods = Society::get_instance()->get_goods();
     int max_num_inputs = std::min<int>(Sim::get_max_num_inputs(), goods.size());
-    static std::uniform_int_distribution<>
+    std::uniform_int_distribution<>
         num_inputs_dist(PRODUCT_NUM_INPUTS_MIN, max_num_inputs);
     const std::size_t num_inputs = num_inputs_dist(Sim::get_random_generator());
     std::uniform_int_distribution<>
@@ -48,7 +48,7 @@ void Product::set_inputs() {
     while (indices.size() < num_inputs) {
         indices.insert(product_input_index_dist(Sim::get_random_generator()));
     }
-    static std::uniform_real_distribution<>
+    std::uniform_real_distribution<>
         input_per_unit_dist(PRODUCT_INPUT_AMOUNT_MIN, PRODUCT_INPUT_AMOUNT_MAX);
     for (int index : indices) {
         inputs_per_unit[goods[index]] =
@@ -64,7 +64,7 @@ void Product::set_machines() {
     const unsigned int global_num_machines = Sim::get_num_machines();
     const int num_machines_max =
         global_num_machines / MAX_PROPORTION_OF_MACHINES_PER_PRODUCT;
-    static std::uniform_int_distribution<>
+    std::uniform_int_distribution<>
         num_machines_dist(PRODUCT_NUM_MACHINES_MIN, num_machines_max);
     const std::size_t num_machines =
         num_machines_dist(Sim::get_random_generator());

--- a/test/test_Producer.cpp
+++ b/test/test_Producer.cpp
@@ -45,13 +45,13 @@ TEST_CASE("Producer Logic Testing") {
     }
 
     SUBCASE("get_max_order_quantity() calculates limits correctly") {
-        int expected_max_quantity = INT_MAX;
+        double expected_max_quantity = std::numeric_limits<double>::infinity(); //grabbed from producer.cpp
         for (std::pair<Good * const, double>& input : test_product->inputs_per_unit) { //manually calculate actual value
             double current_inventory = test_producer->input_inventory[input.first];
             double required_per_unit = input.second;
-            int input_max = static_cast<int>(current_inventory / required_per_unit);
+            double input_max = current_inventory / required_per_unit;
             expected_max_quantity = std::min(expected_max_quantity, input_max); 
         }
-        CHECK(test_producer->get_max_order_quantity(test_product) == expected_max_quantity); //projected vs actual
+        CHECK(test_producer->get_max_order_quantity(test_product) == doctest::Approx(expected_max_quantity)); //projected vs actual
     }
 }


### PR DESCRIPTION
Resolves #268, Resolves #276

Replaced `*.cpp` with `*.o` dependencies in `TEST_DEPS` to properly link object files. 
* Added a dedicated `runtests` rule that automatically builds the tests if they don't exist, changes directories via `pushd`/`popd` and then returns to the root.

Replaced `std::unordered_map` with `std::map` in `header/Firm.h` and `src/Firm.cpp`. 
Implemented a Product ID to sort objects by their integer `id` rather than a temporary memory address.
* Needs further testing to make sure this works.