### PR TITLE
Implement a firm's general account

### DIFF
--- a/header/Firm.h
+++ b/header/Firm.h
@@ -72,10 +72,9 @@ class Firm : public Agent {
     bool start_plan(Plan * plan);
     void handle_start_plan_failure(Plan * plan, Product * product, double missing);
     void return_inputs_to_inventory(
-        std::unordered_map<Product *, double> deducted_inputs,
-        Firm * firm
+        std::unordered_map<Product *, double> deducted_inputs
     );
-    void rollback_plan_inputs(Plan * plan, Firm * firm);
+    void rollback_plan_inputs(Plan * plan);
     void move_plan_forward_one_step(Plan * plan);
     void end_plan(Plan * plan);
     void move_plans_forward_one_step();

--- a/header/Firm.h
+++ b/header/Firm.h
@@ -73,7 +73,7 @@ class Firm : public Agent {
         std::unordered_map<Product *, double> deducted_inputs
         );
     void refund_for_unused_inputs(
-            const std::unordered_map<Product *, double> deducted_inputs);
+            const std::unordered_map<Product *, double> returned_inputs);
     void rollback_plan_inputs(Plan * plan);
     void move_plan_forward_one_step(Plan * plan);
     void end_plan(Plan * plan);

--- a/header/Firm.h
+++ b/header/Firm.h
@@ -34,7 +34,7 @@ class Firm : public Agent {
     void receive_shipment(Plan * plan);
     void receive_payment(Plan * plan, double transaction_amount);
     double get_busyness();
-    double get_pooled_input_value();
+    double get_account();
     std::vector<Person *> propose_transfer(int workers_wanted);
     void finalize_transfer(Person * worker);
 
@@ -42,7 +42,7 @@ class Firm : public Agent {
   protected:
     unsigned int id;
     std::unordered_map<Product *, double> average_team_sizes;
-    double pooled_input_value = 0.0;
+    double account = 0.0;
     std::unordered_set<Person *> workers,
         standby_workers;
     std::unordered_map<Product *, double> input_inventory;

--- a/header/Firm.h
+++ b/header/Firm.h
@@ -57,13 +57,11 @@ class Firm : public Agent {
     Producer * send_order(Order * order);
     bool remove_input_from_inventory(
         Product * product,
-        double quantity,
-        Firm * firm
+        double quantity
     );
     bool remove_input_from_inventory(
         Product * product,
         double quantity,
-        Firm * firm,
         std::unordered_map<Product *, double>& container
     );
     double get_reorder_threshold(Product * product);
@@ -73,7 +71,9 @@ class Firm : public Agent {
     void handle_start_plan_failure(Plan * plan, Product * product, double missing);
     void return_inputs_to_inventory(
         std::unordered_map<Product *, double> deducted_inputs
-    );
+        );
+    void refund_for_unused_inputs(
+            const std::unordered_map<Product *, double> deducted_inputs);
     void rollback_plan_inputs(Plan * plan);
     void move_plan_forward_one_step(Plan * plan);
     void end_plan(Plan * plan);

--- a/header/Firm.h
+++ b/header/Firm.h
@@ -32,7 +32,7 @@ class Firm : public Agent {
     virtual double get_inventory_level(Product * product);
     void receive_shipment(Order * order);
     void receive_shipment(Plan * plan);
-    void receive_payment(Plan * plan, double transaction_amount);
+    void process_payment(Plan * plan, double transaction_amount);
     double get_busyness();
     double get_account();
     std::vector<Person *> propose_transfer(int workers_wanted);

--- a/header/Firm.h
+++ b/header/Firm.h
@@ -146,4 +146,5 @@ class Firm : public Agent {
     );
     void log_catalog();
     void log_catalog_addition(Product * product);
+    void log_account();
 };

--- a/header/Plan.h
+++ b/header/Plan.h
@@ -19,10 +19,8 @@ struct Plan {
     double debt = 0.0;
     double labor_hours_used = 0.0;
     std::unordered_map<Product *, double> inventory;
-    std::unordered_map<Product *, double> needed_this_step;
     std::unordered_map<Product *, double> outlays;
     double quantity_remaining = 0.0;
-    int outgoing_units_consumed = 0;
     bool is_stalled = false;
     Product * missing_resource = nullptr;
 };

--- a/overseer_model/data/plotting_data.yml
+++ b/overseer_model/data/plotting_data.yml
@@ -1256,7 +1256,7 @@ firm_accounts:
       linestyle: solid
       linewidth: 1.5
       markersize: 6.0
-      label_template: Producer {i}'s account
+      label_template: Producer {i}'s Account
       colors: ['']
       traj_key: distributor_accounts
     distributor_accounts:
@@ -1265,7 +1265,7 @@ firm_accounts:
       linestyle: solid
       linewidth: 1.5
       markersize: 6.0
-      label_template: Distributor {i}'s account
+      label_template: Distributor {i}'s Account
       colors: ['']
       traj_key: distributor_accounts
   projection: 2d

--- a/overseer_model/data/plotting_data.yml
+++ b/overseer_model/data/plotting_data.yml
@@ -1257,7 +1257,7 @@ firm_accounts:
       linewidth: 1.5
       markersize: 6.0
       label_template: Producer {i}'s Account
-      colors: [maroon, navy, seagreen, goldenrod, orchid]
+      colors: [chartreuse, goldenrod, navy, pink, maroon]
       traj_key: distributor_accounts
     distributor_accounts:
       checkbox_name: Distributor Accounts
@@ -1266,7 +1266,7 @@ firm_accounts:
       linewidth: 1.5
       markersize: 6.0
       label_template: Distributor {i}'s Account
-      colors: [firebrick, chartreuse, darkturquoise, sandybrown, blueviolet]
+      colors: [darkturquoise, blueviolet, firebrick, olive, darkcyan]
       traj_key: distributor_accounts
   projection: 2d
   axis_visible: true

--- a/overseer_model/data/plotting_data.yml
+++ b/overseer_model/data/plotting_data.yml
@@ -1257,7 +1257,7 @@ firm_accounts:
       linewidth: 1.5
       markersize: 6.0
       label_template: Producer {i}'s Account
-      colors: ['']
+      colors: [maroon, navy, seagreen, goldenrod, orchid]
       traj_key: distributor_accounts
     distributor_accounts:
       checkbox_name: Distributor Accounts
@@ -1266,7 +1266,7 @@ firm_accounts:
       linewidth: 1.5
       markersize: 6.0
       label_template: Distributor {i}'s Account
-      colors: ['']
+      colors: [firebrick, chartreuse, darkturquoise, sandybrown, blueviolet]
       traj_key: distributor_accounts
   projection: 2d
   axis_visible: true

--- a/overseer_model/data/plotting_data.yml
+++ b/overseer_model/data/plotting_data.yml
@@ -1246,3 +1246,31 @@ busyness_data:
   ticks_visible: true
   frame_visible: true
   default_lims: [[0.00498251, 0.263608], [-0.260721, 17.8723]]
+firm_accounts:
+  name: Firm Accounts
+  tooltip: null
+  plots:
+    producer_accounts:
+      checkbox_name: Producer Accounts
+      toggled: true
+      linestyle: solid
+      linewidth: 1.5
+      markersize: 6.0
+      label_template: Producer {i}'s account
+      colors: ['']
+      traj_key: distributor_accounts
+    distributor_accounts:
+      checkbox_name: Distributor Accounts
+      toggled: true
+      linestyle: solid
+      linewidth: 1.5
+      markersize: 6.0
+      label_template: Distributor {i}'s account
+      colors: ['']
+      traj_key: distributor_accounts
+  projection: 2d
+  axis_visible: true
+  grid_visible: true
+  ticks_visible: true
+  frame_visible: true
+  title: Firm Accounts

--- a/overseer_model/simulation/Aggregator.py
+++ b/overseer_model/simulation/Aggregator.py
@@ -142,7 +142,8 @@ class Aggregator:
                 "busyness": self.record_sector_busyness,
                 "accepted_order": self.record_accepted_order,
                 "transfer_request": self.record_transfer_request,
-                "transfer": self.record_employment_transfer
+                "transfer": self.record_employment_transfer,
+                "account": self.record_firm_account
             },
             "Producer": {},
             "Distributor": {}
@@ -171,6 +172,7 @@ class Aggregator:
             "catalog": [],
             "recent_busyness": 0,
             "inc_inventory": np.zeros(self.settings["n_products"]),
+            "account": 0
         } for i in range(self.settings["n_producers"])}
 
         self.distributors = {i: {
@@ -186,6 +188,7 @@ class Aggregator:
             "catalog": [],
             "recent_busyness": 0,
             "inc_inventory": np.zeros(self.settings["n_products"]),
+            "account": 0
 
         } for i in range(self.settings["n_distributors"])}
 
@@ -442,6 +445,9 @@ class Aggregator:
         n_prod_goods = self.settings["n_goods"]
         l_list = list(self.l)
 
+        producer_accounts = np.array([value["account"] for value in self.producers.values()])
+        distributor_accounts = np.array([value["account"] for value in self.distributors.values()])
+
         self.traj = {
             "producer_goods_prices": Append(self.prices[:n_prod_goods]),
             "consumption_goods_prices": Append(self.prices[n_prod_goods:2*n_prod_goods]),
@@ -576,6 +582,8 @@ class Aggregator:
             "start_plan_stall_causes_machines": Append(start_plan_stall_causes_machines),
             "start_plan_stall_causes_deficits_goods": Append(start_plan_stall_deficits_goods),
             "start_plan_stall_causes_deficits_machines": Append(start_plan_stall_deficits_machines),
+            "producer_accounts": Append(producer_accounts),
+            "distributor_accounts": Append(distributor_accounts),
 
         }
         if self.current_t == 0:
@@ -1476,3 +1484,15 @@ class Aggregator:
                 self.transfer_requests_by_sector_t,
                 self.current_t
             )
+    def record_firm_account(self, dic):
+        client = dic["client"]
+        firm_id = dic["id"]
+        value = dic["value"]
+        if client == "Producer":
+            self.producers[firm_id]["account"] = value
+        elif client == "Distributor":
+            firm_id = self._get_dist_key(firm_id)
+            self.distributors[firm_id]["account"] = value
+        else:
+            return
+

--- a/setup.sh
+++ b/setup.sh
@@ -39,9 +39,9 @@ echo "Successfully created binary!"
 echo ""
 echo "Configuring files..."
 USER_CONFIG_DIR="$(python -c '
-    from platformdirs import user_config_dir
-    print(user_config_dir("Overseer", False, roaming=True))
-    '
+from platformdirs import user_config_dir
+print(user_config_dir("Overseer", False, roaming=True))
+'
 )"
 USER_CONFIG_FILE="$USER_CONFIG_DIR/config.yml"
 USER_MODELS_DIR="$SCRIPT_DIR"

--- a/src/Distributor.cpp
+++ b/src/Distributor.cpp
@@ -81,6 +81,7 @@ int Distributor::try_sell_goods(
     } else if (!person->charge(cost)) {
         return 0;
     }
+    account += cost;
     remove_input_from_inventory(consumer_good, available, this);
     PriceController::get_instance()->report_distribution(consumer_good, available);
     return available;

--- a/src/Distributor.cpp
+++ b/src/Distributor.cpp
@@ -82,7 +82,7 @@ int Distributor::try_sell_goods(
         return 0;
     }
     account += cost;
-    remove_input_from_inventory(consumer_good, available, this);
+    remove_input_from_inventory(consumer_good, available);
     PriceController::get_instance()->report_distribution(consumer_good, available);
     return available;
 }

--- a/src/Firm.cpp
+++ b/src/Firm.cpp
@@ -446,6 +446,7 @@ void Firm::move_plan_forward_one_step(Plan * plan) {
     for (std::pair<Product *, double> requirement : plan->needed_this_step) {
         plan->inventory[requirement.first] -= requirement.second;
     }
+    account -= plan->workers.size() * portion_of_hour_worked;
     for (Person * worker : plan->workers) {
     	worker->register_hours_worked(portion_of_hour_worked);
     }

--- a/src/Firm.cpp
+++ b/src/Firm.cpp
@@ -277,12 +277,12 @@ void Firm::return_inputs_to_inventory(
 }
 
 void Firm::refund_for_unused_inputs(
-        const std::unordered_map<Product *, double> deducted_inputs) {
+        const std::unordered_map<Product *, double> returned_inputs) {
     double refund = 0.0;
-    for (const std::pair<Product * const, double>& deduction :
-            deducted_inputs) {
-        Product * input = deduction.first;
-        double quantity = deduction.second;
+    for (const std::pair<Product * const, double>& return :
+            returned_inputs) {
+        Product * input = return.first;
+        double quantity = return.second;
         refund += input->price_per_unit * quantity;
     }
     account += refund;

--- a/src/Firm.cpp
+++ b/src/Firm.cpp
@@ -86,12 +86,12 @@ void Firm::receive_shipment(Plan * plan) {
     double transaction_amount =
         order->product->price_per_unit * quantity_delivered;
     account -= transaction_amount;
-    plan->firm->receive_payment(plan, transaction_amount);
+    plan->firm->process_payment(plan, transaction_amount);
     log_shipment_received(order->product, quantity_delivered);
     log_inventory_level(order->product, input_inventory[order->product]);
 }
 
-void Firm::receive_payment(Plan * plan, double transaction_amount) {
+void Firm::process_payment(Plan * plan, double transaction_amount) {
     plan->debt -= transaction_amount;
 }
 

--- a/src/Firm.cpp
+++ b/src/Firm.cpp
@@ -84,7 +84,7 @@ void Firm::receive_shipment(Plan * plan) {
     product_to_outbound_orders[order->product].erase(order);
     double transaction_amount =
         order->product->price_per_unit * quantity_delivered;
-    pooled_input_value -= transaction_amount;
+    account -= transaction_amount;
     plan->firm->receive_payment(plan, transaction_amount);
     log_shipment_received(order->product, quantity_delivered);
     log_inventory_level(order->product, input_inventory[order->product]);
@@ -92,7 +92,7 @@ void Firm::receive_shipment(Plan * plan) {
 
 void Firm::receive_payment(Plan * plan, double transaction_amount) {
     plan->debt += transaction_amount;
-    pooled_input_value += transaction_amount;
+    account += transaction_amount;
 }
 
 bool Firm::remove_input_from_inventory(
@@ -131,8 +131,8 @@ double Firm::get_busyness() {
     return workers.size() > 0 ? busyness / workers.size() : 0.0;
 }
 
-double Firm::get_pooled_input_value() {
-    return pooled_input_value;
+double Firm::get_account() {
+    return account;
 }
 
 std::vector<Person *> Firm::propose_transfer(int workers_wanted) {
@@ -320,7 +320,7 @@ bool Firm::start_plan(Plan * plan) {
         move_worker_off_standby(worker);
     }
     plan->outlays = plan->inventory;
-    pooled_input_value +=
+    account +=
         plan->raw_materials_budget + plan->machinery_budget;
     if (plan->is_stalled) {
         plan->is_stalled = false;

--- a/src/Firm.cpp
+++ b/src/Firm.cpp
@@ -267,21 +267,19 @@ void Firm::check_and_reorder_input(Product * product) {
 }
 
 void Firm::return_inputs_to_inventory(
-        const std::unordered_map<Product *, double> deducted_inputs,
-        Firm * firm
-    ) {
+        const std::unordered_map<Product *, double> deducted_inputs) {
     for (const std::pair<Product * const, double>& deduction :
             deducted_inputs) {
         Product * input = deduction.first;
         double quantity = deduction.second;
         input_inventory[input] += quantity;
-        add_demand_signal(input, -quantity, firm);
+        add_demand_signal(input, -quantity, this);
         log_inventory_level(input, input_inventory[input]);
     }
 }
 
-void Firm::rollback_plan_inputs(Plan * plan, Firm * firm) {
-    return_inputs_to_inventory(plan->inventory, firm);
+void Firm::rollback_plan_inputs(Plan * plan) {
+    return_inputs_to_inventory(plan->inventory);
     plan->inventory.clear();
     plan->outlays.clear();
     plan->order->status = Order::OrderStatus::kOrderRequested;
@@ -338,7 +336,7 @@ void Firm::handle_start_plan_failure(
     double have_on_hand = get_inventory_level(missing_resource);
     double deficit = amount_needed - have_on_hand;
 
-    rollback_plan_inputs(plan, plan->order->customer);
+    rollback_plan_inputs(plan);
     bool new_stall =
         !plan->is_stalled || plan->missing_resource != missing_resource;
 
@@ -413,7 +411,7 @@ void Firm::move_plan_forward_one_step(Plan * plan) {
                         plan->order->customer,
                         deducted_inputs
                         )) {
-                return_inputs_to_inventory(deducted_inputs, plan->order->customer);
+                return_inputs_to_inventory(deducted_inputs);
 
                 bool new_stall = !plan->is_stalled ||
                     plan->missing_resource != requirement.first;
@@ -461,10 +459,7 @@ void Firm::end_plan(Plan * plan) {
     for (std::pair<Product *, double> input : plan->inventory) {
         plan->outlays[input.first] -= input.second;
     }
-    return_inputs_to_inventory(
-        plan->inventory,
-        plan->order->customer
-    );
+    return_inputs_to_inventory(plan->inventory);
     recorded_living_labor_per_unit[plan->order->product] = 
         plan->labor_hours_used /
         (plan->order->quantity - plan->quantity_remaining); 

--- a/src/Firm.cpp
+++ b/src/Firm.cpp
@@ -398,18 +398,18 @@ void Firm::move_plan_forward_one_step(Plan * plan) {
         return;
     }
     Product * product = plan->order->product;
+    std::unordered_map<Product *, double> needed_this_step;
     for (std::pair<Good *, double> input : product->inputs_per_unit) {
-        plan->needed_this_step[input.first] = input.second * quantity_produced;
+        needed_this_step[input.first] = input.second * quantity_produced;
     }
     double portion_of_hour_worked =
         quantity_produced / expected_quantity_produced;
     for (Machine * machine : product->machines_needed) {
-        plan->needed_this_step[machine] =
-            portion_of_hour_worked / machine->lifetime;
+        needed_this_step[machine] = portion_of_hour_worked / machine->lifetime;
     }
     std::unordered_map<Product*, double> deducted_inputs;
     bool was_stalled = plan->is_stalled;
-    for (std::pair<Product *, double> requirement : plan->needed_this_step) {
+    for (std::pair<Product *, double> requirement : needed_this_step) {
         double have_on_hand = plan->inventory[requirement.first];
         if (have_on_hand < requirement.second) {
             double deficit = requirement.second - have_on_hand;
@@ -419,10 +419,8 @@ void Firm::move_plan_forward_one_step(Plan * plan) {
                         deducted_inputs
                         )) {
                 return_inputs_to_inventory(deducted_inputs);
-
                 bool new_stall = !plan->is_stalled ||
                     plan->missing_resource != requirement.first;
-
                 if (new_stall) {
                     if (plan->is_stalled) {
                         log_plan_stall_resolved(plan);
@@ -448,7 +446,7 @@ void Firm::move_plan_forward_one_step(Plan * plan) {
         plan->inventory[input.first] += input.second;
         plan->outlays[input.first] += input.second;
     }
-    for (std::pair<Product *, double> requirement : plan->needed_this_step) {
+    for (std::pair<Product *, double> requirement : needed_this_step) {
         plan->inventory[requirement.first] -= requirement.second;
     }
     account -= plan->workers.size() * portion_of_hour_worked;

--- a/src/Firm.cpp
+++ b/src/Firm.cpp
@@ -92,17 +92,15 @@ void Firm::receive_shipment(Plan * plan) {
 }
 
 void Firm::receive_payment(Plan * plan, double transaction_amount) {
-    plan->debt += transaction_amount;
-    account += transaction_amount;
+    plan->debt -= transaction_amount;
 }
 
 bool Firm::remove_input_from_inventory(
         Product * product,
         double quantity,
-        Firm * firm,
         std::unordered_map<Product *, double>& deducted_inputs
     ) {
-    if (remove_input_from_inventory(product, quantity, firm)) {
+    if (remove_input_from_inventory(product, quantity)) {
         deducted_inputs[product] += quantity;
         return true;
     }
@@ -111,14 +109,13 @@ bool Firm::remove_input_from_inventory(
 
 bool Firm::remove_input_from_inventory(
         Product * product,
-        double quantity,
-        Firm * firm
+        double quantity
     ) {
     if (!input_inventory.count(product) || input_inventory[product] < quantity) {
         return false;
     }
     input_inventory[product] -= quantity;
-    add_demand_signal(product, quantity, firm);
+    add_demand_signal(product, quantity, this);
     log_inventory_reduction(product, quantity);
     log_inventory_level(product, input_inventory[product]);
     return true;
@@ -279,6 +276,19 @@ void Firm::return_inputs_to_inventory(
     }
 }
 
+void Firm::refund_for_unused_inputs(
+        const std::unordered_map<Product *, double> deducted_inputs) {
+    double refund = 0.0;
+    for (const std::pair<Product * const, double>& deduction :
+            deducted_inputs) {
+        Product * input = deduction.first;
+        double quantity = deduction.second;
+        refund += input->price_per_unit * quantity;
+    }
+    account += refund;
+}
+
+
 void Firm::rollback_plan_inputs(Plan * plan) {
     return_inputs_to_inventory(plan->inventory);
     plan->inventory.clear();
@@ -289,13 +299,13 @@ void Firm::rollback_plan_inputs(Plan * plan) {
 bool Firm::start_plan(Plan * plan) {
     plans_in_progress.insert(plan);
     plan->order->status = Order::kOrderInProgress;
+    account += plan->debt;
     Product * product = plan->order->product;
     for (std::pair<Good * const, double>& input : product->inputs_per_unit) {
         double amount_needed = input.second * plan->order->quantity;
         if (!remove_input_from_inventory(
                     input.first,
                     amount_needed,
-                    plan->order->customer,
                     plan->inventory
                 )) {
             handle_start_plan_failure(plan, input.first, amount_needed);
@@ -308,7 +318,6 @@ bool Firm::start_plan(Plan * plan) {
         if (!remove_input_from_inventory(
                     machine,
                     expected_machine_use,
-                    plan->order->customer,
                     plan->inventory
                 )) {
             handle_start_plan_failure(plan, machine, expected_machine_use);
@@ -319,8 +328,6 @@ bool Firm::start_plan(Plan * plan) {
         move_worker_off_standby(worker);
     }
     plan->outlays = plan->inventory;
-    account +=
-        plan->raw_materials_budget + plan->machinery_budget;
     if (plan->is_stalled) {
         plan->is_stalled = false;
         plan->missing_resource = nullptr;
@@ -409,7 +416,6 @@ void Firm::move_plan_forward_one_step(Plan * plan) {
             if (!remove_input_from_inventory(
                         requirement.first,
                         deficit,
-                        plan->order->customer,
                         deducted_inputs
                         )) {
                 return_inputs_to_inventory(deducted_inputs);
@@ -457,10 +463,13 @@ void Firm::end_plan(Plan * plan) {
     log_ended_plan(plan);
     plan->order->status = Order::kOrderFinished;
     plan->order->customer->receive_shipment(plan);
+    account -= plan->debt;
     for (std::pair<Product *, double> input : plan->inventory) {
         plan->outlays[input.first] -= input.second;
     }
     return_inputs_to_inventory(plan->inventory);
+    refund_for_unused_inputs(plan->inventory);
+    account += plan->labor_budget - plan->labor_hours_used;
     recorded_living_labor_per_unit[plan->order->product] = 
         plan->labor_hours_used /
         (plan->order->quantity - plan->quantity_remaining); 
@@ -624,11 +633,9 @@ void Firm::initialize_plan_budget(Plan * draft_plan) {
     draft_plan->machinery_budget = calculate_machinery_cost_for_plan(draft_plan);
     draft_plan->raw_materials_budget = calculate_raw_material_cost_for_order(draft_plan->order);
     draft_plan->quantity_remaining = draft_plan->order->quantity;
-    draft_plan->debt = -(
-            draft_plan->machinery_budget +
+    draft_plan->debt = draft_plan->machinery_budget +
             draft_plan->raw_materials_budget +
-            draft_plan->labor_budget
-            );
+            draft_plan->labor_budget;
 }
 
 double Firm::calculate_machinery_cost_for_plan(Plan * draft_plan) {

--- a/src/Firm.cpp
+++ b/src/Firm.cpp
@@ -279,10 +279,10 @@ void Firm::return_inputs_to_inventory(
 void Firm::refund_for_unused_inputs(
         const std::unordered_map<Product *, double> returned_inputs) {
     double refund = 0.0;
-    for (const std::pair<Product * const, double>& return :
+    for (const std::pair<Product * const, double>& returned_input :
             returned_inputs) {
-        Product * input = return.first;
-        double quantity = return.second;
+        Product * input = returned_input.first;
+        double quantity = returned_input.second;
         refund += input->price_per_unit * quantity;
     }
     account += refund;

--- a/src/Firm.cpp
+++ b/src/Firm.cpp
@@ -51,6 +51,7 @@ void Firm::on_time_step() {
     }
     double firm_busyness = get_busyness();
     log_busyness(firm_busyness);
+    log_account();
 }
 
 void Firm::inject_randomness_into_demand() {
@@ -972,4 +973,13 @@ void Firm::log_start_plan_stall_resolved(Plan * plan) {
         LogPair("plan_id", plan->id),
         LogPair("product_id", plan->order->product->id)
     );
+}
+
+void Firm::log_account() {
+    Logger::log(
+            get_client_type(),
+            id,
+            "account",
+            LogPair("value", account)
+            );
 }


### PR DESCRIPTION
Resolves #243 

# Sequence of Events
- When a firm buys machinery and input goods, it pays for them out of its general account (its `account`).
- When a firm drafts a plan, it drafts a budget with three line items — `machinery_budget`, `raw_materials_budget`, and `labor_budget`. A fourth item, `debt`, is simply the sum of these three. (Note that I have switched this to a _positive_ sum. It is the quantity of debt created by fiat when the budget is put into effect.)
- When a firm starts executing a plan, in `start_plan`, it transfers the value of the three lines (or, equivalently, the debt), as a positive value, to its account, for use in paying for machinery, inputs, and labor.
- When the firm moves the plan forward on each time step, it pays its workers from its account.
- When the firm completes the plan, in `end_plan`, 
  - It ships the order to the customer and receives payment, which is _deducted_ from the plan's debt.
    - If the total value of the shipped product equals the original budget, the debt will come down to 0. 
    - If the price has come down since this firm began executing its plan, because the average necessary direct or indirect labor has decreased, a portion of the debt will remain.
    - If the price has increased since the firm started executing the plan, the debt will be less than 0.
  - It _subtracts_ the debt from its general account. This ensures that the account will reflect the degree to which the firm has gotten reimbursed for its expenditures on the plan by selling its output products to the ordering customer.
    - If the debt is still positive, this will decrease the general account.
    - If the debt is negative, it will increase the account, showing that the firm has sold its goods for more than what it had originally budgeted.
  - it adds (refunds) the value of any unused inputs (including machine capacity) to the account. This ensures that the amount put into the account, by the end of the plan, reflects the plan's actual expenditures.

The new _Firm Accounts_ graph shows how the firms' accounts oscillate within a small range, hovering around 0:
<img width="1555" height="1192" alt="Screenshot 2026-08-13 at 10 30 26 PM" src="https://github.com/user-attachments/assets/c7e3377c-b1b2-4d53-8212-e6b5447286db" />
