### PR TITLE
Ignore and clean .dSYM debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ myenv
 
 # debug information files
 *.dwo
+*.dSYM/
 
 # Python cache and build artifacts
 __pycache__/

--- a/makefile
+++ b/makefile
@@ -101,7 +101,7 @@ graphs: trace plot-tool
 clean:
 	rm -rf $(wildcard ${BIN_DIR}/*) $(wildcard ${BUILD_DIR}/*) $(wildcard ${TEST_DIR}/*.test) \
 		$(wildcard ${DATA_DIR}/*) \
-		*.gcno *.gcda *.profraw *.profdata *.info out_coverage/ test/*.gcno test/*.gcda
+		*.gcno *.gcda *.profraw *.profdata *.info out_coverage/ test/*.gcno test/*.gcda *.dSYM test/*.dSYM
 
 coverage: FLAGS += --coverage
 coverage: clean tests


### PR DESCRIPTION
Resolves #301 

Added `*.dSYM/` to `.gitignore` and updated the clean target in the `Makefile` to delete root and test `.dSYM` folders. This should prevent all branch switching errors on macOS.